### PR TITLE
Implement UpdateEl for &String and String

### DIFF
--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -122,9 +122,21 @@ impl<Ms: Clone> UpdateEl<El<Ms>> for WillUnmount<Ms> {
 }
 
 impl<Ms: Clone> UpdateEl<El<Ms>> for &str {
-    // This, or some other mechanism seems to work for String too... note sure why.
     fn update(self, el: &mut El<Ms>) {
         el.children.push(Node::Text(Text::new(self.to_string())))
+    }
+}
+
+impl<Ms: Clone> UpdateEl<El<Ms>> for &String {
+    fn update(self, el: &mut El<Ms>) {
+        el.children.push(Node::Text(Text::new(self.clone())))
+    }
+}
+
+impl<Ms: Clone> UpdateEl<El<Ms>> for String {
+    // This, or some other mechanism seems to work for String too... note sure why.
+    fn update(self, el: &mut El<Ms>) {
+        el.children.push(Node::Text(Text::new(self)))
     }
 }
 


### PR DESCRIPTION
Prevents cryptic errors when reference or owned string is passed.