### PR TITLE
New AppBuilderAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 - Fixed jumping cursor in inputs (#158) 
 - Added method `orders.after_next_render(Option<RenderTimestampDelta>)` (#207)
 - Fixed a bug with back/forward routing to the landing page (#296)
+- [BREAKING] Deprecated `Init` struct, replacing it with `BeforeMount` and `AfterMount` structs to
+better denote state before and after mounting the `App` occurs.
+- [BREAKING] Added a new function `builder` which replaces `build` as part of deprecating `Init`.
+- [BREAKING] Added a new function `build` which replaces `finish` as part of deprecating `Init`.
+- Added `IntoInit`, `IntoAfterMount`, and `IntoBeforeMount` traits. It is possible to use these
+in place of a closure or function to produce the corresponding `Init`, `AfterMount`, and
+`BeforeMount` structs.
 
 ## v0.4.2
 - Added an `Init` struct, which can help with initial routing (Breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ better denote state before and after mounting the `App` occurs.
 - Added `IntoInit`, `IntoAfterMount`, and `IntoBeforeMount` traits. It is possible to use these
 in place of a closure or function to produce the corresponding `Init`, `AfterMount`, and
 `BeforeMount` structs.
+- Messages sent from `IntoAfterMount` will now be run after the routing message.
 
 ## v0.4.2
 - Added an `Init` struct, which can help with initial routing (Breaking)

--- a/examples/animation_frame/src/lib.rs
+++ b/examples/animation_frame/src/lib.rs
@@ -51,13 +51,13 @@ struct Model {
     car: Car,
 }
 
-// Init
+// AfterMount
 
-fn init(_: Url, orders: &mut impl Orders<Msg>) -> Init<Model> {
+fn after_mount(_: Url, orders: &mut impl Orders<Msg>) -> AfterMount<Model> {
     orders
         .send_msg(Msg::SetViewportWidth)
         .after_next_render(Msg::Rendered);
-    Init::new(Model::default())
+    AfterMount::default()
 }
 
 // Update
@@ -162,7 +162,8 @@ fn view_wheel(wheel_x: f64, car: &Car) -> Node<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(init, update, view)
+    seed::App::builder(update, view)
+        .after_mount(after_mount)
         .window_events(|_| vec![simple_ev(Ev::Resize, Msg::SetViewportWidth)])
         .build_and_start();
 }

--- a/examples/canvas/src/lib.rs
+++ b/examples/canvas/src/lib.rs
@@ -18,11 +18,11 @@ struct Model {
     fill_color: Color,
 }
 
-// Init
+// AfterMount
 
-fn init(_: Url, orders: &mut impl Orders<Msg>) -> Init<Model> {
+fn after_mount(_: Url, orders: &mut impl Orders<Msg>) -> AfterMount<Model> {
     orders.after_next_render(|_| Msg::Rendered);
-    Init::new(Model {
+    AfterMount::new(Model {
         fill_color: COLOR_A,
     })
 }
@@ -87,5 +87,7 @@ fn view(_model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(init, update, view).build_and_start();
+    seed::App::builder(update, view)
+        .after_mount(after_mount)
+        .build_and_start();
 }

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -105,5 +105,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view).build_and_start();
+    seed::App::builder(update, view).build_and_start();
 }

--- a/examples/drop/README.md
+++ b/examples/drop/README.md
@@ -1,6 +1,6 @@
 ## Drop example
 
-How to crate a drop-zone.
+How to create a drop-zone.
 
 ---
 

--- a/examples/drop/src/lib.rs
+++ b/examples/drop/src/lib.rs
@@ -11,10 +11,10 @@ struct Model {
     drop_zone_content: Vec<Node<Msg>>,
 }
 
-// Init
+// AfterMount
 
-fn init(_: Url, _: &mut impl Orders<Msg>) -> Init<Model> {
-    Init::new(Model {
+fn after_mount(_: Url, _: &mut impl Orders<Msg>) -> AfterMount<Model> {
+    AfterMount::new(Model {
         drop_zone_active: false,
         drop_zone_content: vec![div!["Drop files here"]],
     })
@@ -117,5 +117,7 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(init, update, view).build_and_start();
+    seed::App::builder(update, view)
+        .after_mount(after_mount)
+        .build_and_start();
 }

--- a/examples/drop/src/lib.rs
+++ b/examples/drop/src/lib.rs
@@ -11,15 +11,6 @@ struct Model {
     drop_zone_content: Vec<Node<Msg>>,
 }
 
-// AfterMount
-
-fn after_mount(_: Url, _: &mut impl Orders<Msg>) -> AfterMount<Model> {
-    AfterMount::new(Model {
-        drop_zone_active: false,
-        drop_zone_content: vec![div!["Drop files here"]],
-    })
-}
-
 // Update
 
 #[derive(Clone, Debug)]
@@ -118,6 +109,9 @@ fn view(model: &Model) -> impl View<Msg> {
 #[wasm_bindgen(start)]
 pub fn start() {
     seed::App::builder(update, view)
-        .after_mount(after_mount)
+        .after_mount(AfterMount::new(Model {
+            drop_zone_active: false,
+            drop_zone_content: vec![div!["Drop files here"]],
+        }))
         .build_and_start();
 }

--- a/examples/mathjax/src/lib.rs
+++ b/examples/mathjax/src/lib.rs
@@ -226,13 +226,7 @@ fn view(model: &Model) -> impl View<Msg> {
     ]
 }
 
-// Init
-
-fn init(_: Url, _: &mut impl Orders<Msg>) -> Init<Model> {
-    Init::new(Model::default())
-}
-
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(init, update, view).build_and_start();
+    seed::App::builder(update, view).build_and_start();
 }

--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -93,5 +93,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view).build_and_start();
+    seed::App::builder(update, view).build_and_start();
 }

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -107,5 +107,5 @@ fn view_example_introduction(title: &str, description: &str) -> Vec<Node<Msg>> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view).build_and_start();
+    seed::App::builder(update, view).build_and_start();
 }

--- a/examples/server_interaction/src/lib.rs
+++ b/examples/server_interaction/src/lib.rs
@@ -128,12 +128,14 @@ fn view(model: &Model) -> Vec<Node<Msg>> {
 
 // Init
 
-fn init(_: Url, orders: &mut impl Orders<Msg>) -> Init<Model> {
+fn after_mount(_: Url, orders: &mut impl Orders<Msg>) -> AfterMount<Model> {
     orders.perform_cmd(fetch_repository_info());
-    Init::new(Model::default())
+    AfterMount::default()
 }
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(init, update, view).build_and_start();
+    seed::App::builder(update, view)
+        .after_mount(after_mount)
+        .build_and_start();
 }

--- a/examples/server_interaction_detailed/reports/src/lib.rs
+++ b/examples/server_interaction_detailed/reports/src/lib.rs
@@ -304,9 +304,7 @@ fn view(model: &Model) -> Vec<El<Msg>> {
 
 #[wasm_bindgen]
 pub fn render() {
-    let state = seed::App::build(Model::default(), update, view)
-        .finish()
-        .run();
+    let state = seed::App::builder(update, view).build_and_start();
 
     state.update(Msg::GetData)
 }

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -361,7 +361,7 @@ fn routes(url: seed::Url) -> Option<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view)
+    seed::App::builder(update, view)
         .routes(routes)
         .build_and_start();
 }

--- a/examples/update_from_js/src/lib.rs
+++ b/examples/update_from_js/src/lib.rs
@@ -12,12 +12,6 @@ struct Model {
     time_from_js: Option<String>,
 }
 
-// Init
-
-fn init(_: Url, _: &mut impl Orders<Msg>) -> Init<Model> {
-    Init::new(Model::default())
-}
-
 // Update
 
 #[derive(Clone)]
@@ -76,7 +70,7 @@ fn view(model: &Model) -> Node<Msg> {
 #[wasm_bindgen]
 // `wasm-bindgen` cannot transfer struct with public closures to JS (yet) so we have to send slice.
 pub fn start() -> Box<[JsValue]> {
-    let app = seed::App::build(init, update, view).build_and_start();
+    let app = seed::App::builder(update, view).build_and_start();
 
     create_closures_for_js(&app)
 }

--- a/examples/user_media/src/lib.rs
+++ b/examples/user_media/src/lib.rs
@@ -12,11 +12,11 @@ use web_sys::{HtmlMediaElement, MediaStream, MediaStreamConstraints};
 
 struct Model {}
 
-// Init
+// AfterMount
 
-fn init(_: Url, orders: &mut impl Orders<Msg>) -> Init<Model> {
+fn after_mount(_: Url, orders: &mut impl Orders<Msg>) -> AfterMount<Model> {
     orders.perform_cmd(user_media());
-    Init::new(Model {})
+    AfterMount::new(Model {})
 }
 
 fn user_media() -> impl Future<Item = Msg, Error = Msg> {
@@ -74,5 +74,7 @@ fn view(_: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    seed::App::build(init, update, view).build_and_start();
+    seed::App::builder(update, view)
+        .after_mount(after_mount)
+        .build_and_start();
 }

--- a/examples/websocket/src/client.rs
+++ b/examples/websocket/src/client.rs
@@ -23,7 +23,7 @@ struct Model {
 
 // Init
 
-fn init(_: Url, orders: &mut impl Orders<Msg>) -> Init<Model> {
+fn after_mount(_: Url, orders: &mut impl Orders<Msg>) -> AfterMount<Model> {
     let ws = WebSocket::new(WS_URL).unwrap();
 
     register_ws_handler(WebSocket::set_onopen, Msg::Connected, &ws, orders);
@@ -31,7 +31,7 @@ fn init(_: Url, orders: &mut impl Orders<Msg>) -> Init<Model> {
     register_ws_handler(WebSocket::set_onmessage, Msg::ServerMessage, &ws, orders);
     register_ws_handler(WebSocket::set_onerror, Msg::Error, &ws, orders);
 
-    Init::new(Model {
+    AfterMount::new(Model {
         ws,
         connected: false,
         msg_rx_cnt: 0,
@@ -154,5 +154,7 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    App::build(init, update, view).build_and_start();
+    App::builder(update, view)
+        .after_mount(after_mount)
+        .build_and_start();
 }

--- a/examples/window_events/src/lib.rs
+++ b/examples/window_events/src/lib.rs
@@ -83,7 +83,7 @@ fn window_events(model: &Model) -> Vec<Listener<Msg>> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view)
+    seed::App::builder(update, view)
         .window_events(window_events)
         .build_and_start();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub mod prelude {
             request_animation_frame, ClosureNew, RequestAnimationFrameHandle,
             RequestAnimationFrameTime,
         },
-        vdom::{Init, MountType, RenderTimestampDelta, UrlHandling},
+        vdom::{AfterMount, BeforeMount, Init, MountType, RenderTimestampDelta, UrlHandling},
     };
     pub use indexmap::IndexMap; // for attrs and style to work.
     pub use wasm_bindgen::prelude::*;

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -110,6 +110,11 @@ impl<Ms, Mdl, ElC: View<Ms>, GMs> OrdersContainer<Ms, Mdl, ElC, GMs> {
             app,
         }
     }
+
+    pub(crate) fn append_from(&mut self, mut other: Self) {
+        self.should_render = other.should_render;
+        self.effects.append(&mut other.effects);
+    }
 }
 
 impl<Ms: 'static, Mdl, ElC: View<Ms> + 'static, GMs> Orders<Ms, GMs>

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -111,7 +111,7 @@ impl<Ms, Mdl, ElC: View<Ms>, GMs> OrdersContainer<Ms, Mdl, ElC, GMs> {
         }
     }
 
-    pub(crate) fn append_from(&mut self, mut other: Self) {
+    pub(crate) fn merge(&mut self, mut other: Self) {
         self.should_render = other.should_render;
         self.effects.append(&mut other.effects);
     }

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -349,14 +349,14 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
         match url_handling {
             UrlHandling::PassToRoutes => {
                 let url = routing::current_url();
-                if let Some(routes) = self.data.routes.borrow().as_ref() {
-                    if let Some(routing_msg) = routes(url) {
-                        (self.cfg.update)(
-                            routing_msg,
-                            &mut self.data.model.borrow_mut().as_mut().unwrap(),
-                            &mut orders,
-                        );
-                    }
+                let routing_msg = self
+                    .data
+                    .routes
+                    .borrow()
+                    .as_ref()
+                    .and_then(|routes| routes(url));
+                if let Some(routing_msg) = routing_msg {
+                    orders.effects.push_back(routing_msg.into());
                 }
             }
             UrlHandling::None => (),

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -125,10 +125,10 @@ pub struct AppData<Ms: 'static, Mdl> {
     pub render_timestamp: Cell<Option<RenderTimestamp>>,
 }
 
-type OptDynRunCfg<Ms, Mdl, ElC, GMs> =
-    Option<AppRunCfg<Ms, Mdl, ElC, GMs, dyn builder::IntoAfterMount<Ms, Mdl, ElC, GMs>>>;
+type OptDynInitCfg<Ms, Mdl, ElC, GMs> =
+    Option<AppInitCfg<Ms, Mdl, ElC, GMs, dyn builder::IntoAfterMount<Ms, Mdl, ElC, GMs>>>;
 
-pub struct AppRunCfg<Ms, Mdl, ElC, GMs, IAM: ?Sized>
+pub struct AppInitCfg<Ms, Mdl, ElC, GMs, IAM: ?Sized>
 where
     Ms: 'static,
     Mdl: 'static,
@@ -161,7 +161,7 @@ where
     ElC: View<Ms>,
 {
     /// Temporary app configuration that is removed after app begins running.
-    pub run_cfg: OptDynRunCfg<Ms, Mdl, ElC, GMs>,
+    pub init_cfg: OptDynInitCfg<Ms, Mdl, ElC, GMs>,
     /// App configuration available for the entire application lifetime.
     pub cfg: Rc<AppCfg<Ms, Mdl, ElC, GMs>>,
     /// Mutable app state
@@ -216,13 +216,13 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
         mount_point: Element,
         routes: Option<RoutesFn<Ms>>,
         window_events: Option<WindowEvents<Ms, Mdl>>,
-        run_cfg: OptDynRunCfg<Ms, Mdl, ElC, GMs>,
+        init_cfg: OptDynInitCfg<Ms, Mdl, ElC, GMs>,
     ) -> Self {
         let window = util::window();
         let document = window.document().expect("Can't find the window's document");
 
         Self {
-            run_cfg,
+            init_cfg,
             cfg: Rc::new(AppCfg {
                 document,
                 mount_point,
@@ -325,12 +325,12 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
         note = "Please use `AppBuilder.build_and_start` instead"
     )]
     pub fn run(mut self) -> Self {
-        let AppRunCfg {
+        let AppInitCfg {
             mount_type,
             into_after_mount,
             ..
-        } = self.run_cfg.take().expect(
-            "`run_cfg` should be set in `App::new` which is called from `AppBuilder::build_and_start`",
+        } = self.init_cfg.take().expect(
+            "`init_cfg` should be set in `App::new` which is called from `AppBuilder::build_and_start`",
         );
 
         // Bootstrap the virtual DOM.
@@ -622,7 +622,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
 impl<Ms, Mdl, ElC: View<Ms>, GMs> Clone for App<Ms, Mdl, ElC, GMs> {
     fn clone(&self) -> Self {
         Self {
-            run_cfg: None,
+            init_cfg: None,
             cfg: Rc::clone(&self.cfg),
             data: Rc::clone(&self.data),
         }

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -14,8 +14,10 @@ use next_tick::NextTick;
 
 pub mod alias;
 pub use alias::*;
+
+// Building process.
 pub mod builder;
-pub use builder::{Builder as AppBuilder, Init, MountType, UrlHandling};
+pub use builder::{Builder as AppBuilder, MountPoint, MountType, UrlHandling, Init};
 
 use crate::{
     dom_types::{self, El, MessageMapper, Namespace, Node, View},

--- a/src/vdom/builder.rs
+++ b/src/vdom/builder.rs
@@ -4,7 +4,7 @@ use crate::{
     dom_types::View,
     orders::OrdersContainer,
     routing,
-    vdom::{alias::*, App, AppRunCfg},
+    vdom::{alias::*, App, AppInitCfg},
 };
 
 pub mod init;
@@ -124,7 +124,7 @@ impl<
         let mut initial_orders = OrdersContainer::new(app.clone());
         let init = into_init.into_init(routing::current_url(), &mut initial_orders);
 
-        app.run_cfg.replace(AppRunCfg {
+        app.init_cfg.replace(AppInitCfg {
             mount_type: init.mount_type,
             into_after_mount: Box::new((init, initial_orders)),
             phantom: PhantomData,
@@ -162,7 +162,7 @@ impl<
             mount_point.element(),
             builder.routes,
             builder.window_events,
-            Some(AppRunCfg {
+            Some(AppInitCfg {
                 mount_type,
                 into_after_mount: Box::new(into_after_mount),
                 phantom: PhantomData,

--- a/src/vdom/builder.rs
+++ b/src/vdom/builder.rs
@@ -8,11 +8,11 @@ use crate::{
 };
 
 pub mod init;
-pub use init::{Fn as InitFn, Init, Into as IntoInit};
+pub use init::{Init, InitFn, IntoInit};
 pub mod before_mount;
-pub use before_mount::{BeforeMount, Into as IntoBeforeMount, MountPoint, MountType};
+pub use before_mount::{BeforeMount, IntoBeforeMount, MountPoint, MountType};
 pub mod after_mount;
-pub use after_mount::{AfterMount, Into as IntoAfterMount, UrlHandling};
+pub use after_mount::{AfterMount, IntoAfterMount, UrlHandling};
 
 #[deprecated(
     since = "0.5.0",

--- a/src/vdom/builder.rs
+++ b/src/vdom/builder.rs
@@ -14,14 +14,20 @@ pub use before_mount::{BeforeMount, Into as IntoBeforeMount, MountPoint, MountTy
 pub mod after_mount;
 pub use after_mount::{AfterMount, Into as IntoAfterMount, UrlHandling};
 
+#[deprecated(
+    since = "0.4.3",
+    note = "Used for compatability with old Init API. Use `BeforeAfterInitAPI` together with `BeforeMount` and `AfterMount` instead."
+)]
 pub struct MountPointInitInitAPI<MP, II> {
     mount_point: MP,
     into_init: II,
 }
+// TODO Remove when removing the other `InitAPI`s.
 pub struct BeforeAfterInitAPI<IBM, IAM> {
     into_before_mount: IBM,
     into_after_mount: IAM,
 }
+// TODO Remove when removing the other `InitAPI`s.
 impl Default for BeforeAfterInitAPI<(), ()> {
     fn default() -> Self {
         BeforeAfterInitAPI {
@@ -31,14 +37,24 @@ impl Default for BeforeAfterInitAPI<(), ()> {
     }
 }
 
+// TODO Remove when removing the other `InitAPI`s.
 pub trait InitAPI<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
     type Builder;
     fn build(builder: Self::Builder) -> App<Ms, Mdl, ElC, GMs>;
 }
+// TODO Remove when removing the other `InitAPI`s.
 pub trait InitAPIData {
     type IntoBeforeMount;
     type IntoAfterMount;
+    #[deprecated(
+        since = "0.4.3",
+        note = "Used for compatability with old Init API. Use `IntoBeforeMount` and `IntoAfterMount` instead."
+    )]
     type IntoInit;
+    #[deprecated(
+        since = "0.4.3",
+        note = "Used for compatability with old Init API. Use `IntoBeforeMount` and `IntoAfterMount` instead."
+    )]
     type MountPoint;
 
     fn before_mount<NewIBM: IntoBeforeMount>(
@@ -56,16 +72,29 @@ pub trait InitAPIData {
         into_after_mount: NewIAM,
     ) -> BeforeAfterInitAPI<Self::IntoBeforeMount, NewIAM>;
 
+    #[deprecated(
+        since = "0.4.3",
+        note = "Used for compatability with old Init API. Use `before_mount` and `after_mount` instead."
+    )]
     fn init<Ms: 'static, Mdl, ElC: View<Ms>, GMs, NewII: IntoInit<Ms, Mdl, ElC, GMs>>(
         self,
         into_init: NewII,
     ) -> MountPointInitInitAPI<Self::MountPoint, NewII>;
+    #[deprecated(
+        since = "0.4.3",
+        note = "Used for compatability with old Init API. Use `before_mount` and `after_mount` instead."
+    )]
     fn mount<NewMP: MountPoint>(
         self,
         mount_point: NewMP,
     ) -> MountPointInitInitAPI<NewMP, Self::IntoInit>;
 }
 
+// TODO Remove when removing the other `InitAPI`s.
+#[deprecated(
+    since = "0.4.3",
+    note = "Used for compatability with old Init API. Use `BeforeAfterInitAPI` together with `BeforeMount` and `AfterMount` instead."
+)]
 impl<
         Ms: 'static,
         Mdl: 'static,
@@ -104,6 +133,7 @@ impl<
         app
     }
 }
+// TODO Remove when removing the other `InitAPI`s.
 impl<
         Ms: 'static,
         Mdl: 'static,
@@ -140,6 +170,7 @@ impl<
         )
     }
 }
+// TODO Remove when removing the other `InitAPI`s.
 impl<Ms: 'static, Mdl: 'static + Default, ElC: 'static + View<Ms>, GMs: 'static>
     InitAPI<Ms, Mdl, ElC, GMs> for ()
 {
@@ -158,6 +189,10 @@ impl<Ms: 'static, Mdl: 'static + Default, ElC: 'static + View<Ms>, GMs: 'static>
     }
 }
 
+#[deprecated(
+    since = "0.4.3",
+    note = "Used for compatability with old Init API. Use `BeforeAfterInitAPI` together with `BeforeMount` and `AfterMount` instead."
+)]
 impl<MP, II> InitAPIData for MountPointInitInitAPI<MP, II> {
     type IntoBeforeMount = ();
     type IntoAfterMount = ();
@@ -208,6 +243,7 @@ impl<MP, II> InitAPIData for MountPointInitInitAPI<MP, II> {
         }
     }
 }
+// TODO Remove when removing the other `InitAPI`s.
 impl<IBM, IAM> InitAPIData for BeforeAfterInitAPI<IBM, IAM> {
     type IntoBeforeMount = IBM;
     type IntoAfterMount = IAM;
@@ -258,6 +294,7 @@ impl<IBM, IAM> InitAPIData for BeforeAfterInitAPI<IBM, IAM> {
         }
     }
 }
+// TODO Remove when removing the other `InitAPI`s.
 impl InitAPIData for () {
     type IntoBeforeMount = ();
     type IntoAfterMount = ();
@@ -350,6 +387,10 @@ impl<
         InitAPIType: InitAPIData<IntoInit = II, MountPoint = MP, IntoBeforeMount = IBM, IntoAfterMount = IAM>,
     > Builder<Ms, Mdl, ElC, GMs, InitAPIType>
 {
+    #[deprecated(
+        since = "0.4.3",
+        note = "Used for compatability with old Init API. Use `before_mount` and `after_mount` instead."
+    )]
     pub fn init<NewII: IntoInit<Ms, Mdl, ElC, GMs>>(
         self,
         new_init: NewII,
@@ -383,6 +424,10 @@ impl<
     /// // argument is `Element`
     /// mount(seed::body().querySelector("section").unwrap().unwrap())
     /// ```
+    #[deprecated(
+        since = "0.4.3",
+        note = "Used for compatability with old Init API. Use `before_mount` and `after_mount` instead."
+    )]
     pub fn mount<NewMP: MountPoint>(
         self,
         new_mount_point: NewMP,

--- a/src/vdom/builder.rs
+++ b/src/vdom/builder.rs
@@ -15,8 +15,8 @@ pub mod after_mount;
 pub use after_mount::{AfterMount, Into as IntoAfterMount, UrlHandling};
 
 #[deprecated(
-    since = "0.4.3",
-    note = "Used for compatability with old Init API. Use `BeforeAfterInitAPI` together with `BeforeMount` and `AfterMount` instead."
+    since = "0.5.0",
+    note = "Used for compatibility with old Init API. Use `BeforeAfterInitAPI` together with `BeforeMount` and `AfterMount` instead."
 )]
 pub struct MountPointInitInitAPI<MP, II> {
     mount_point: MP,
@@ -47,13 +47,13 @@ pub trait InitAPIData {
     type IntoBeforeMount;
     type IntoAfterMount;
     #[deprecated(
-        since = "0.4.3",
-        note = "Used for compatability with old Init API. Use `IntoBeforeMount` and `IntoAfterMount` instead."
+        since = "0.5.0",
+        note = "Used for compatibility with old Init API. Use `IntoBeforeMount` and `IntoAfterMount` instead."
     )]
     type IntoInit;
     #[deprecated(
-        since = "0.4.3",
-        note = "Used for compatability with old Init API. Use `IntoBeforeMount` and `IntoAfterMount` instead."
+        since = "0.5.0",
+        note = "Used for compatibility with old Init API. Use `IntoBeforeMount` and `IntoAfterMount` instead."
     )]
     type MountPoint;
 
@@ -73,16 +73,16 @@ pub trait InitAPIData {
     ) -> BeforeAfterInitAPI<Self::IntoBeforeMount, NewIAM>;
 
     #[deprecated(
-        since = "0.4.3",
-        note = "Used for compatability with old Init API. Use `before_mount` and `after_mount` instead."
+        since = "0.5.0",
+        note = "Used for compatibility with old Init API. Use `before_mount` and `after_mount` instead."
     )]
     fn init<Ms: 'static, Mdl, ElC: View<Ms>, GMs, NewII: IntoInit<Ms, Mdl, ElC, GMs>>(
         self,
         into_init: NewII,
     ) -> MountPointInitInitAPI<Self::MountPoint, NewII>;
     #[deprecated(
-        since = "0.4.3",
-        note = "Used for compatability with old Init API. Use `before_mount` and `after_mount` instead."
+        since = "0.5.0",
+        note = "Used for compatibility with old Init API. Use `before_mount` and `after_mount` instead."
     )]
     fn mount<NewMP: MountPoint>(
         self,
@@ -92,8 +92,8 @@ pub trait InitAPIData {
 
 // TODO Remove when removing the other `InitAPI`s.
 #[deprecated(
-    since = "0.4.3",
-    note = "Used for compatability with old Init API. Use `BeforeAfterInitAPI` together with `BeforeMount` and `AfterMount` instead."
+    since = "0.5.0",
+    note = "Used for compatibility with old Init API. Use `BeforeAfterInitAPI` together with `BeforeMount` and `AfterMount` instead."
 )]
 impl<
         Ms: 'static,
@@ -190,8 +190,8 @@ impl<Ms: 'static, Mdl: 'static + Default, ElC: 'static + View<Ms>, GMs: 'static>
 }
 
 #[deprecated(
-    since = "0.4.3",
-    note = "Used for compatability with old Init API. Use `BeforeAfterInitAPI` together with `BeforeMount` and `AfterMount` instead."
+    since = "0.5.0",
+    note = "Used for compatibility with old Init API. Use `BeforeAfterInitAPI` together with `BeforeMount` and `AfterMount` instead."
 )]
 impl<MP, II> InitAPIData for MountPointInitInitAPI<MP, II> {
     type IntoBeforeMount = ();
@@ -388,8 +388,8 @@ impl<
     > Builder<Ms, Mdl, ElC, GMs, InitAPIType>
 {
     #[deprecated(
-        since = "0.4.3",
-        note = "Used for compatability with old Init API. Use `before_mount` and `after_mount` instead."
+        since = "0.5.0",
+        note = "Used for compatibility with old Init API. Use `before_mount` and `after_mount` instead."
     )]
     pub fn init<NewII: IntoInit<Ms, Mdl, ElC, GMs>>(
         self,
@@ -425,8 +425,8 @@ impl<
     /// mount(seed::body().querySelector("section").unwrap().unwrap())
     /// ```
     #[deprecated(
-        since = "0.4.3",
-        note = "Used for compatability with old Init API. Use `before_mount` and `after_mount` instead."
+        since = "0.5.0",
+        note = "Used for compatibility with old Init API. Use `before_mount` and `after_mount` instead."
     )]
     pub fn mount<NewMP: MountPoint>(
         self,

--- a/src/vdom/builder/after_mount.rs
+++ b/src/vdom/builder/after_mount.rs
@@ -47,7 +47,8 @@ impl<Mdl> AfterMount<Mdl> {
     }
 }
 
-pub trait Into<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
+#[allow(clippy::module_name_repetitions)]
+pub trait IntoAfterMount<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
     fn into_after_mount(
         self: Box<Self>,
         init_url: Url,
@@ -55,7 +56,7 @@ pub trait Into<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
     ) -> AfterMount<Mdl>;
 }
 
-impl<Ms: 'static, Mdl: Default, ElC: View<Ms>, GMs> Into<Ms, Mdl, ElC, GMs> for AfterMount<Mdl> {
+impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs> IntoAfterMount<Ms, Mdl, ElC, GMs> for AfterMount<Mdl> {
     fn into_after_mount(
         self: Box<Self>,
         _: Url,
@@ -65,7 +66,7 @@ impl<Ms: 'static, Mdl: Default, ElC: View<Ms>, GMs> Into<Ms, Mdl, ElC, GMs> for 
     }
 }
 
-impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs, F> Into<Ms, Mdl, ElC, GMs> for F
+impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs, F> IntoAfterMount<Ms, Mdl, ElC, GMs> for F
 where
     F: FnOnce(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> AfterMount<Mdl>,
 {
@@ -78,7 +79,7 @@ where
     }
 }
 
-impl<Ms: 'static, Mdl: Default, ElC: View<Ms>, GMs> Into<Ms, Mdl, ElC, GMs> for () {
+impl<Ms: 'static, Mdl: Default, ElC: View<Ms>, GMs> IntoAfterMount<Ms, Mdl, ElC, GMs> for () {
     fn into_after_mount(
         self: Box<Self>,
         _: Url,

--- a/src/vdom/builder/after_mount.rs
+++ b/src/vdom/builder/after_mount.rs
@@ -1,14 +1,4 @@
-use web_sys::Element;
-
-use crate::{
-    dom_types::View,
-    orders::OrdersContainer,
-    routing, util,
-    vdom::{
-        alias::*,
-        App,
-    },
-};
+use crate::{dom_types::View, orders::OrdersContainer, routing::Url};
 
 /// Used for handling initial routing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -18,3 +8,69 @@ pub enum UrlHandling {
     // todo: Expand later, as-required
 }
 
+impl Default for UrlHandling {
+    fn default() -> Self {
+        Self::PassToRoutes
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AfterMount<Mdl> {
+    pub model: Mdl,
+    pub url_handling: UrlHandling,
+}
+
+impl<Mdl> AfterMount<Mdl> {
+    pub fn new(model: Mdl) -> Self {
+        Self {
+            model,
+            url_handling: UrlHandling::default(),
+        }
+    }
+
+    // TODO: Change to const fn when possible.
+    // TODO: Relevant issue: https://github.com/rust-lang/rust/issues/60964
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn model<NewMdl>(self, model: NewMdl) -> AfterMount<NewMdl> {
+        AfterMount {
+            model,
+            url_handling: self.url_handling,
+        }
+    }
+
+    pub const fn url_handling(mut self, url_handling: UrlHandling) -> Self {
+        self.url_handling = url_handling;
+        self
+    }
+}
+
+pub trait Into<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
+    fn into_after_mount(
+        self: Box<Self>,
+        init_url: Url,
+        orders: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
+    ) -> AfterMount<Mdl>;
+}
+
+impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs, F> Into<Ms, Mdl, ElC, GMs> for F
+where
+    F: FnOnce(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> AfterMount<Mdl>,
+{
+    fn into_after_mount(
+        self: Box<Self>,
+        init_url: Url,
+        orders: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
+    ) -> AfterMount<Mdl> {
+        self(init_url, orders)
+    }
+}
+
+impl<Ms: 'static, Mdl: Default, ElC: View<Ms>, GMs> Into<Ms, Mdl, ElC, GMs> for () {
+    fn into_after_mount(
+        self: Box<Self>,
+        _: Url,
+        _: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
+    ) -> AfterMount<Mdl> {
+        AfterMount::default()
+    }
+}

--- a/src/vdom/builder/after_mount.rs
+++ b/src/vdom/builder/after_mount.rs
@@ -16,7 +16,10 @@ impl Default for UrlHandling {
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AfterMount<Mdl> {
+    /// Initial model to be used when the app begins.
     pub model: Mdl,
+    /// How to handle initial url routing. Defaults to [`UrlHandling::PassToRoutes`] in the
+    /// constructors.
     pub url_handling: UrlHandling,
 }
 
@@ -50,6 +53,16 @@ pub trait Into<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
         init_url: Url,
         orders: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
     ) -> AfterMount<Mdl>;
+}
+
+impl<Ms: 'static, Mdl: Default, ElC: View<Ms>, GMs> Into<Ms, Mdl, ElC, GMs> for AfterMount<Mdl> {
+    fn into_after_mount(
+        self: Box<Self>,
+        _: Url,
+        _: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
+    ) -> AfterMount<Mdl> {
+        *self
+    }
 }
 
 impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs, F> Into<Ms, Mdl, ElC, GMs> for F

--- a/src/vdom/builder/after_mount.rs
+++ b/src/vdom/builder/after_mount.rs
@@ -1,0 +1,20 @@
+use web_sys::Element;
+
+use crate::{
+    dom_types::View,
+    orders::OrdersContainer,
+    routing, util,
+    vdom::{
+        alias::*,
+        App,
+    },
+};
+
+/// Used for handling initial routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UrlHandling {
+    PassToRoutes,
+    None,
+    // todo: Expand later, as-required
+}
+

--- a/src/vdom/builder/before_mount.rs
+++ b/src/vdom/builder/before_mount.rs
@@ -56,9 +56,11 @@ impl Default for MountType {
     }
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BeforeMount<MP: MountPoint> {
     pub mount_point: MP,
+    /// How to handle elements already present in the mount. Defaults to [`MountType::Append`]
+    /// in the constructors.
     pub mount_type: MountType,
 }
 
@@ -83,9 +85,22 @@ impl<MP: MountPoint> BeforeMount<MP> {
     }
 }
 
+impl Default for BeforeMount<()> {
+    fn default() -> Self {
+        Self::new(())
+    }
+}
+
 pub trait Into {
     type MP: MountPoint;
     fn into_before_mount(self, init_url: Url) -> BeforeMount<Self::MP>;
+}
+
+impl<MP: MountPoint> Into for BeforeMount<MP> {
+    type MP = MP;
+    fn into_before_mount(self, _: Url) -> BeforeMount<MP> {
+        self
+    }
 }
 
 impl<MP: MountPoint, F> Into for F

--- a/src/vdom/builder/before_mount.rs
+++ b/src/vdom/builder/before_mount.rs
@@ -1,0 +1,51 @@
+use web_sys::Element;
+
+use crate::{
+    util,
+    vdom::{
+        alias::*,
+        App,
+    },
+};
+
+pub trait MountPoint {
+    fn element(self) -> Element;
+}
+
+impl MountPoint for &str {
+    fn element(self) -> Element {
+        util::document().get_element_by_id(self).unwrap_or_else(|| {
+            panic!(
+                "Can't find element with id={:?} - app cannot be mounted!\n\
+                 (Id defaults to \"app\", or can be set with the .mount() method)",
+                self
+            )
+        })
+    }
+}
+
+impl MountPoint for Element {
+    fn element(self) -> Element {
+        self
+    }
+}
+
+impl MountPoint for web_sys::HtmlElement {
+    fn element(self) -> Element {
+        self.into()
+    }
+}
+
+/// Describes the handling of elements already present in the mount element.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MountType {
+    /// Take control of previously existing elements in the mount. This does not make guarantees of
+    /// elements added after the [`App`] has been mounted.
+    ///
+    /// Note that existing elements in the DOM will be recreated. This can be dangerous for script
+    /// tags and other, similar tags.
+    Takeover,
+    /// Leave the previously existing elements in the mount alone. This does not make guarantees of
+    /// elements added after the [`App`] has been mounted.
+    Append,
+}

--- a/src/vdom/builder/before_mount.rs
+++ b/src/vdom/builder/before_mount.rs
@@ -91,19 +91,20 @@ impl Default for BeforeMount<()> {
     }
 }
 
-pub trait Into {
+#[allow(clippy::module_name_repetitions)]
+pub trait IntoBeforeMount {
     type MP: MountPoint;
     fn into_before_mount(self, init_url: Url) -> BeforeMount<Self::MP>;
 }
 
-impl<MP: MountPoint> Into for BeforeMount<MP> {
+impl<MP: MountPoint> IntoBeforeMount for BeforeMount<MP> {
     type MP = MP;
     fn into_before_mount(self, _: Url) -> BeforeMount<MP> {
         self
     }
 }
 
-impl<MP: MountPoint, F> Into for F
+impl<MP: MountPoint, F> IntoBeforeMount for F
 where
     F: FnOnce(Url) -> BeforeMount<MP>,
 {
@@ -113,7 +114,7 @@ where
     }
 }
 
-impl Into for () {
+impl IntoBeforeMount for () {
     type MP = ();
     fn into_before_mount(self, _: Url) -> BeforeMount<Self::MP> {
         BeforeMount::default()

--- a/src/vdom/builder/before_mount.rs
+++ b/src/vdom/builder/before_mount.rs
@@ -1,12 +1,6 @@
 use web_sys::Element;
 
-use crate::{
-    util,
-    vdom::{
-        alias::*,
-        App,
-    },
-};
+use crate::{routing::Url, util};
 
 pub trait MountPoint {
     fn element(self) -> Element;
@@ -36,6 +30,12 @@ impl MountPoint for web_sys::HtmlElement {
     }
 }
 
+impl MountPoint for () {
+    fn element(self) -> Element {
+        "app".element()
+    }
+}
+
 /// Describes the handling of elements already present in the mount element.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MountType {
@@ -48,4 +48,59 @@ pub enum MountType {
     /// Leave the previously existing elements in the mount alone. This does not make guarantees of
     /// elements added after the [`App`] has been mounted.
     Append,
+}
+
+impl Default for MountType {
+    fn default() -> Self {
+        Self::Append
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BeforeMount<MP: MountPoint> {
+    pub mount_point: MP,
+    pub mount_type: MountType,
+}
+
+impl<MP: MountPoint> BeforeMount<MP> {
+    pub fn new(mp: MP) -> Self {
+        Self {
+            mount_point: mp,
+            mount_type: MountType::default(),
+        }
+    }
+
+    pub fn mount_point<NewMP: MountPoint>(self, new_mp: NewMP) -> BeforeMount<NewMP> {
+        BeforeMount {
+            mount_point: new_mp,
+            mount_type: self.mount_type,
+        }
+    }
+
+    pub fn mount_type(mut self, new_mt: MountType) -> Self {
+        self.mount_type = new_mt;
+        self
+    }
+}
+
+pub trait Into {
+    type MP: MountPoint;
+    fn into_before_mount(self, init_url: Url) -> BeforeMount<Self::MP>;
+}
+
+impl<MP: MountPoint, F> Into for F
+where
+    F: FnOnce(Url) -> BeforeMount<MP>,
+{
+    type MP = MP;
+    fn into_before_mount(self, init_url: Url) -> BeforeMount<MP> {
+        self(init_url)
+    }
+}
+
+impl Into for () {
+    type MP = ();
+    fn into_before_mount(self, _: Url) -> BeforeMount<Self::MP> {
+        BeforeMount::default()
+    }
 }

--- a/src/vdom/builder/init.rs
+++ b/src/vdom/builder/init.rs
@@ -98,7 +98,7 @@ impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs> IntoAfterMount<Ms, Mdl, ElC, GMs>
         ord: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
     ) -> AfterMount<Mdl> {
         let (init, old_ord) = *self;
-        ord.append_from(old_ord);
+        ord.merge(old_ord);
         AfterMount {
             model: init.model,
             url_handling: init.url_handling,

--- a/src/vdom/builder/init.rs
+++ b/src/vdom/builder/init.rs
@@ -1,0 +1,73 @@
+use web_sys::Element;
+
+use crate::{
+    dom_types::View,
+    orders::OrdersContainer,
+    routing::Url, util,
+    vdom::{
+        alias::*,
+        App,
+        builder::{
+            before_mount::{MountPoint, MountType},
+            after_mount::{UrlHandling},
+        },
+    },
+};
+
+
+/// Used as a flexible wrapper for the init function.
+pub struct Init<Mdl> {
+    /// Initial model to be used when the app begins.
+    pub model: Mdl,
+    /// How to handle initial url routing. Defaults to [`UrlHandling::PassToRoutes`] in the
+    /// constructors.
+    pub url_handling: UrlHandling,
+    /// How to handle elements already present in the mount. Defaults to [`MountType::Append`]
+    /// in the constructors.
+    pub mount_type: MountType,
+}
+
+impl<Mdl> Init<Mdl> {
+    pub const fn new(model: Mdl) -> Self {
+        Self {
+            model,
+            url_handling: UrlHandling::PassToRoutes,
+            mount_type: MountType::Append,
+        }
+    }
+
+    pub const fn new_with_url_handling(model: Mdl, url_handling: UrlHandling) -> Self {
+        Self {
+            model,
+            url_handling,
+            mount_type: MountType::Append,
+        }
+    }
+}
+
+impl<Mdl: Default> Default for Init<Mdl> {
+    fn default() -> Self {
+        Self {
+            model: Mdl::default(),
+            url_handling: UrlHandling::PassToRoutes,
+            mount_type: MountType::Append,
+        }
+    }
+}
+
+pub type InitFn<Ms, Mdl, ElC, GMs> =
+    Box<dyn FnOnce(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>>;
+
+pub trait IntoInit<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
+    fn into_init(self, init_url: Url, ord: &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>;
+}
+
+impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs, F> IntoInit<Ms, Mdl, ElC, GMs>
+    for F
+    where
+        F: FnOnce(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>,
+{
+    fn into_init(self, init_url: Url, ord: &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl> {
+        self(init_url, ord)
+    }
+}

--- a/src/vdom/builder/init.rs
+++ b/src/vdom/builder/init.rs
@@ -11,27 +11,27 @@ use crate::{
 /// Used as a flexible wrapper for the init function.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[deprecated(
-    since = "0.4.3",
+    since = "0.5.0",
     note = "Part of old Init API. Use a combination of `BeforeMount` and `AfterMount` instead."
 )]
 pub struct Init<Mdl> {
     /// Initial model to be used when the app begins.
     #[deprecated(
-        since = "0.4.3",
+        since = "0.5.0",
         note = "Part of old Init API. Use `AfterMount` instead."
     )]
     pub model: Mdl,
     /// How to handle initial url routing. Defaults to [`UrlHandling::PassToRoutes`] in the
     /// constructors.
     #[deprecated(
-        since = "0.4.3",
+        since = "0.5.0",
         note = "Part of old Init API. Use `AfterMount` instead."
     )]
     pub url_handling: UrlHandling,
     /// How to handle elements already present in the mount. Defaults to [`MountType::Append`]
     /// in the constructors.
     #[deprecated(
-        since = "0.4.3",
+        since = "0.5.0",
         note = "Part of old Init API. Use `BeforeMount` instead."
     )]
     pub mount_type: MountType,
@@ -39,7 +39,7 @@ pub struct Init<Mdl> {
 
 impl<Mdl> Init<Mdl> {
     #[deprecated(
-        since = "0.4.3",
+        since = "0.5.0",
         note = "Part of old Init API. Use `AfterMount` instead."
     )]
     pub const fn new(model: Mdl) -> Self {
@@ -51,7 +51,7 @@ impl<Mdl> Init<Mdl> {
     }
 
     #[deprecated(
-        since = "0.4.3",
+        since = "0.5.0",
         note = "Part of old Init API. Use `AfterMount` instead."
     )]
     pub const fn new_with_url_handling(model: Mdl, url_handling: UrlHandling) -> Self {
@@ -64,14 +64,14 @@ impl<Mdl> Init<Mdl> {
 }
 
 #[deprecated(
-    since = "0.4.3",
+    since = "0.5.0",
     note = "Part of old Init API. Use `AfterMount` instead."
 )]
 pub type Fn<Ms, Mdl, ElC, GMs> =
     Box<dyn FnOnce(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>>;
 
 #[deprecated(
-    since = "0.4.3",
+    since = "0.5.0",
     note = "Part of old Init API. Use `IntoAfterMount` and `IntoBeforeMount` instead."
 )]
 pub trait Into<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {

--- a/src/vdom/builder/init.rs
+++ b/src/vdom/builder/init.rs
@@ -3,7 +3,7 @@ use crate::{
     orders::OrdersContainer,
     routing::Url,
     vdom::builder::{
-        after_mount::{AfterMount, Into as IntoAfterMount, UrlHandling},
+        after_mount::{AfterMount, IntoAfterMount, UrlHandling},
         before_mount::MountType,
     },
 };
@@ -63,22 +63,24 @@ impl<Mdl> Init<Mdl> {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 #[deprecated(
     since = "0.5.0",
     note = "Part of old Init API. Use `AfterMount` instead."
 )]
-pub type Fn<Ms, Mdl, ElC, GMs> =
+pub type InitFn<Ms, Mdl, ElC, GMs> =
     Box<dyn FnOnce(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>>;
 
+#[allow(clippy::module_name_repetitions)]
 #[deprecated(
     since = "0.5.0",
     note = "Part of old Init API. Use `IntoAfterMount` and `IntoBeforeMount` instead."
 )]
-pub trait Into<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
+pub trait IntoInit<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
     fn into_init(self, init_url: Url, ord: &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>;
 }
 
-impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs, F> Into<Ms, Mdl, ElC, GMs> for F
+impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs, F> IntoInit<Ms, Mdl, ElC, GMs> for F
 where
     F: FnOnce(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>,
 {
@@ -96,8 +98,7 @@ impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs> IntoAfterMount<Ms, Mdl, ElC, GMs>
         ord: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
     ) -> AfterMount<Mdl> {
         let (init, old_ord) = *self;
-        ord.effects = old_ord.effects;
-        ord.should_render = old_ord.should_render;
+        ord.append_from(old_ord);
         AfterMount {
             model: init.model,
             url_handling: init.url_handling,

--- a/src/vdom/builder/init.rs
+++ b/src/vdom/builder/init.rs
@@ -10,18 +10,38 @@ use crate::{
 
 /// Used as a flexible wrapper for the init function.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[deprecated(
+    since = "0.4.3",
+    note = "Part of old Init API. Use a combination of `BeforeMount` and `AfterMount` instead."
+)]
 pub struct Init<Mdl> {
     /// Initial model to be used when the app begins.
+    #[deprecated(
+        since = "0.4.3",
+        note = "Part of old Init API. Use `AfterMount` instead."
+    )]
     pub model: Mdl,
     /// How to handle initial url routing. Defaults to [`UrlHandling::PassToRoutes`] in the
     /// constructors.
+    #[deprecated(
+        since = "0.4.3",
+        note = "Part of old Init API. Use `AfterMount` instead."
+    )]
     pub url_handling: UrlHandling,
     /// How to handle elements already present in the mount. Defaults to [`MountType::Append`]
     /// in the constructors.
+    #[deprecated(
+        since = "0.4.3",
+        note = "Part of old Init API. Use `BeforeMount` instead."
+    )]
     pub mount_type: MountType,
 }
 
 impl<Mdl> Init<Mdl> {
+    #[deprecated(
+        since = "0.4.3",
+        note = "Part of old Init API. Use `AfterMount` instead."
+    )]
     pub const fn new(model: Mdl) -> Self {
         Self {
             model,
@@ -30,6 +50,10 @@ impl<Mdl> Init<Mdl> {
         }
     }
 
+    #[deprecated(
+        since = "0.4.3",
+        note = "Part of old Init API. Use `AfterMount` instead."
+    )]
     pub const fn new_with_url_handling(model: Mdl, url_handling: UrlHandling) -> Self {
         Self {
             model,
@@ -39,9 +63,17 @@ impl<Mdl> Init<Mdl> {
     }
 }
 
+#[deprecated(
+    since = "0.4.3",
+    note = "Part of old Init API. Use `AfterMount` instead."
+)]
 pub type Fn<Ms, Mdl, ElC, GMs> =
     Box<dyn FnOnce(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>>;
 
+#[deprecated(
+    since = "0.4.3",
+    note = "Part of old Init API. Use `IntoAfterMount` and `IntoBeforeMount` instead."
+)]
 pub trait Into<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
     fn into_init(self, init_url: Url, ord: &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>;
 }


### PR DESCRIPTION
Here's an implementation for the new API (#250) that I've been toying around with.

I may have gone a little crazy on the types.... I could have also combined 4 of the fields in the new `AppBuilder` struct into 2, but it might have been (even more) confusing, so I left it as is.

It should still support everything for the older version, and I haven't marked the old methods as deprecated yet.

I also haven't gotten around to converting the examples yet, but I've been up pretty much all night at this point, so I'll fix it later.