### PR TITLE
Rename trait fn map_message to map_msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [unreleased]
 
+- [BREAKING] `MessageMapper::map_message` changed to `MessageMapper::map_msg`.
+
 ## v0.5.0
 - Added helper `seed::canvas()`, and `seed::canvas_context()` helper functions.
 - Fixed `Url` parsing (resolves issue with hash routing).

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -61,27 +61,27 @@ fn view(model: &Model) -> impl View<Msg> {
         view_example_introduction(example_a::TITLE, example_a::DESCRIPTION),
         example_a::view(&model.example_a)
             .els()
-            .map_message(Msg::ExampleA),
+            .map_msg(Msg::ExampleA),
         // example_b
         view_example_introduction(example_b::TITLE, example_b::DESCRIPTION),
         example_b::view(&model.example_b)
             .els()
-            .map_message(Msg::ExampleB),
+            .map_msg(Msg::ExampleB),
         // example_c
         view_example_introduction(example_c::TITLE, example_c::DESCRIPTION),
         example_c::view(&model.example_c)
             .els()
-            .map_message(Msg::ExampleC),
+            .map_msg(Msg::ExampleC),
         // example_d
         view_example_introduction(example_d::TITLE, example_d::DESCRIPTION),
         example_d::view(&model.example_d)
             .els()
-            .map_message(Msg::ExampleD),
+            .map_msg(Msg::ExampleD),
         // example_e
         view_example_introduction(example_e::TITLE, example_e::DESCRIPTION),
         example_e::view(&model.example_e)
             .els()
-            .map_message(Msg::ExampleE),
+            .map_msg(Msg::ExampleE),
     ]
     .into_iter()
     .flatten()

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -18,7 +18,7 @@ pub mod values;
 
 pub trait MessageMapper<Ms, OtherMs> {
     type SelfWithOtherMs;
-    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Self::SelfWithOtherMs;
+    fn map_msg(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Self::SelfWithOtherMs;
 }
 
 /// Common Namespaces
@@ -887,9 +887,9 @@ impl<Ms> Node<Ms> {
 impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Node<Ms> {
     type SelfWithOtherMs = Node<OtherMs>;
     /// See note on impl for El
-    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Node<OtherMs> {
+    fn map_msg(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Node<OtherMs> {
         match self {
-            Node::Element(el) => Node::Element(el.map_message(f)),
+            Node::Element(el) => Node::Element(el.map_msg(f)),
             Node::Text(text) => Node::Text(text),
             Node::Empty => Node::Empty,
         }
@@ -898,9 +898,9 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Node<Ms> {
 
 impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Vec<Node<Ms>> {
     type SelfWithOtherMs = Vec<Node<OtherMs>>;
-    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Vec<Node<OtherMs>> {
+    fn map_msg(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Vec<Node<OtherMs>> {
         self.into_iter()
-            .map(|node| node.map_message(f.clone()))
+            .map(|node| node.map_msg(f.clone()))
             .collect()
     }
 }
@@ -956,7 +956,7 @@ impl<Ms> fmt::Debug for LifecycleHooks<Ms> {
 
 impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for LifecycleHooks<Ms> {
     type SelfWithOtherMs = LifecycleHooks<OtherMs>;
-    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Self::SelfWithOtherMs {
+    fn map_msg(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Self::SelfWithOtherMs {
         LifecycleHooks {
             did_mount: self.did_mount.map(|d| DidMount {
                 actions: d.actions,
@@ -984,7 +984,7 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for El<Ms> {
     /// # Note
     /// There is an overhead to calling this versus keeping all messages under one type.
     /// The deeper the nested structure of children, the more time this will take to run.
-    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> El<OtherMs> {
+    fn map_msg(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> El<OtherMs> {
         El {
             tag: self.tag,
             attrs: self.attrs,
@@ -992,26 +992,24 @@ impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for El<Ms> {
             listeners: self
                 .listeners
                 .into_iter()
-                .map(|l| l.map_message(f.clone()))
+                .map(|l| l.map_msg(f.clone()))
                 .collect(),
             children: self
                 .children
                 .into_iter()
-                .map(|c| c.map_message(f.clone()))
+                .map(|c| c.map_msg(f.clone()))
                 .collect(),
             node_ws: self.node_ws,
             namespace: self.namespace,
-            hooks: self.hooks.map_message(f),
+            hooks: self.hooks.map_msg(f),
         }
     }
 }
 
 impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Vec<El<Ms>> {
     type SelfWithOtherMs = Vec<El<OtherMs>>;
-    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Vec<El<OtherMs>> {
-        self.into_iter()
-            .map(|el| el.map_message(f.clone()))
-            .collect()
+    fn map_msg(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Vec<El<OtherMs>> {
+        self.into_iter().map(|el| el.map_msg(f.clone())).collect()
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -273,7 +273,7 @@ impl<Ms> PartialEq for Listener<Ms> {
 
 impl<Ms: 'static, OtherMs: 'static> MessageMapper<Ms, OtherMs> for Listener<Ms> {
     type SelfWithOtherMs = Listener<OtherMs>;
-    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Listener<OtherMs> {
+    fn map_msg(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Listener<OtherMs> {
         Listener {
             trigger: self.trigger,
             handler: self.handler.map(enclose!((f) |mut eh| {

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -264,7 +264,7 @@ impl<'a, Ms: 'static, AppMs: 'static, Mdl, ElC: View<AppMs> + 'static, GMs> Orde
         let f = self.f.clone();
         self.orders_container
             .effects
-            .push_back(Effect::Msg(msg).map_message(move |ms| f(ms)));
+            .push_back(Effect::Msg(msg).map_msg(move |ms| f(ms)));
         self
     }
 
@@ -274,7 +274,7 @@ impl<'a, Ms: 'static, AppMs: 'static, Mdl, ElC: View<AppMs> + 'static, GMs> Orde
         C: Future<Item = Ms, Error = Ms> + 'static,
     {
         let f = self.f.clone();
-        let effect = Effect::Cmd(Box::new(cmd)).map_message(move |ms| f(ms));
+        let effect = Effect::Cmd(Box::new(cmd)).map_msg(move |ms| f(ms));
         self.orders_container.effects.push_back(effect);
         self
     }

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -47,7 +47,7 @@ impl<Ms, GMs> From<Ms> for Effect<Ms, GMs> {
 
 impl<Ms: 'static, OtherMs: 'static, GMs> MessageMapper<Ms, OtherMs> for Effect<Ms, GMs> {
     type SelfWithOtherMs = Effect<OtherMs, GMs>;
-    fn map_message(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Effect<OtherMs, GMs> {
+    fn map_msg(self, f: impl FnOnce(Ms) -> OtherMs + 'static + Clone) -> Effect<OtherMs, GMs> {
         match self {
             Effect::Msg(msg) => Effect::Msg(f(msg)),
             Effect::Cmd(cmd) => Effect::Cmd(Box::new(cmd.map(f.clone()).map_err(f))),


### PR DESCRIPTION
This patch alignes the public API of `MessageMapper::map_msg` with `Orders::send_msg`.
This is a breaking change.