### PR TITLE
feat: Make attributes more convenient

### DIFF
--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -226,7 +226,7 @@ fn todo_item(item: &Todo, posit: usize, edit_text: &str) -> Node<Msg> {
                 attrs! {
                    At::Class => "toggle",
                    At::Type => "checkbox",
-                   At::Checked => item.completed.as_at_value()
+                   At::Checked => item.completed,
                 },
                 simple_ev(Ev::Click, Msg::Toggle(posit))
             ],
@@ -317,7 +317,7 @@ fn view(model: &Model) -> impl View<Msg> {
             input![
                 attrs! {
                     At::Id => "toggle-all"; At::Class => "toggle-all"; At::Type => "checkbox",
-                    At::Checked => (model.active_count() == 0).as_at_value(),
+                    At::Checked => model.active_count() == 0,
                 },
                 simple_ev(Ev::Click, Msg::ToggleAll)
             ],

--- a/src/dom_types/values.rs
+++ b/src/dom_types/values.rs
@@ -79,39 +79,34 @@ impl<T: ToString> ToCSSValueForOptionToString for Option<T> {
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AtValue {
-    /// The whole attribute is ignored (i.e. not rendered).
-    Ignored,
+    /// Boolean attribute value.
+    Bool(bool),
     /// Attribute value is not used (i.e. rendered as empty string).
-    None,
-    /// Rendered attribute value.
-    Some(String),
+    Empty,
+    /// String attribute value.
+    String(String), // TODO: try Cow<str>?
 }
 
-impl<T: ToString> From<T> for AtValue {
-    fn from(value: T) -> Self {
-        AtValue::Some(value.to_string())
+impl From<bool> for AtValue {
+    fn from(value: bool) -> Self {
+        AtValue::Bool(value)
     }
 }
 
-// `&` because `attrs!` macro automatically adds prefix `&` before values for more ergonomic API
-// (otherwise it would fail when you use for example a Model's property in View functions as `AtValue`)
-impl From<&AtValue> for AtValue {
-    fn from(value: &AtValue) -> Self {
-        value.clone()
+impl From<String> for AtValue {
+    fn from(value: String) -> Self {
+        AtValue::String(value)
     }
 }
 
-// -- AsAtValue --
-
-pub trait AsAtValue {
-    fn as_at_value(&self) -> AtValue;
+impl From<&str> for AtValue {
+    fn from(value: &str) -> Self {
+        AtValue::String(value.to_string())
+    }
 }
 
-impl AsAtValue for bool {
-    fn as_at_value(&self) -> AtValue {
-        match self {
-            true => AtValue::None,
-            false => AtValue::Ignored,
-        }
+impl From<Option<()>> for AtValue {
+    fn from(_value: Option<()>) -> Self {
+        AtValue::Empty
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,8 @@ pub mod prelude {
         css_units::*,
         dom_entity_names::styles::St,
         dom_types::{
-            did_mount, did_update, will_unmount, AsAtValue, At, AtValue, CSSValue, El,
-            MessageMapper, Node, Tag, UpdateEl, View,
+            did_mount, did_update, will_unmount, At, AtValue, CSSValue, El, MessageMapper, Node,
+            Tag, UpdateEl, View,
         },
         events::{
             input_ev, keyboard_ev, mouse_ev, pointer_ev, raw_ev, simple_ev, trigger_update_handler,

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -82,12 +82,12 @@ where
     {
         let listener = if let Some(checked) = el.attrs.vals.get(&dom_types::At::Checked) {
             events::Listener::new_control_check(match checked {
-                AtValue::Some(_) => true,
+                AtValue::String(_) => true,
                 _ => false,
             })
         } else if let Some(control_val) = el.attrs.vals.get(&dom_types::At::Value) {
             events::Listener::new_control(match control_val {
-                AtValue::Some(value) => value.clone(),
+                AtValue::String(value) => value.clone(),
                 _ => "".into(),
             })
         } else {

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -204,7 +204,7 @@ macro_rules! attrs {
                 // We can handle arguments of multiple types by using this:
                 // Strings, &strs, bools, numbers etc.
                 // And cases like `true.as_attr_value()` or `AtValue::Ignored`.
-                vals.insert($key.into(), (&$value).into());
+                vals.insert($key.into(), AtValue::from($value));
             )*
             $crate::dom_types::Attrs::new(vals)
         }

--- a/src/vdom.rs
+++ b/src/vdom.rs
@@ -990,7 +990,7 @@ pub mod tests {
                 &parent,
                 &mailbox,
                 vdom,
-                div![button![attrs! { At::Disabled => false.as_at_value() }]],
+                div![button![attrs! { At::Disabled => false }]],
                 &app,
             );
 
@@ -1010,7 +1010,7 @@ pub mod tests {
                 &parent,
                 &mailbox,
                 vdom,
-                div![button![attrs! { At::Disabled => true.as_at_value() }]],
+                div![button![attrs! { At::Disabled => true }]],
                 &app,
             );
 
@@ -1033,7 +1033,7 @@ pub mod tests {
                 &parent,
                 &mailbox,
                 vdom,
-                div![button![attrs! { At::Disabled => false.as_at_value() }]],
+                div![button![attrs! { At::Disabled => false }]],
                 &app,
             );
 

--- a/tests/attrs.rs
+++ b/tests/attrs.rs
@@ -1,0 +1,13 @@
+use seed::{prelude::*, *};
+
+#[test]
+fn test_attrs() {
+    let attrs = attrs! {
+        At::Class => "foo",
+        At::Charset => String::from("utf8"),
+        At::Hidden => true,
+        At::Disabled => false,
+        At::AutoFocus => None,
+    };
+    assert_eq!(attrs.vals.get(&At::Class), Some(&AtValue::from("foo")));
+}


### PR DESCRIPTION
This is an experimental approach to attributes.
Please take a look at test file I've added: tests/attrs.rs

### Motivation
When I was reading the guide I found `.as_at_value` which was slightly confusing.
I assume that `bool` and regular strings are more common use case, then say using custom enums with `ToString` implementation. As such I think that common cases should be as simple and straightforward as possible.

### Proposal
 - Accept bare `bool`, `&str`, `String`, `&String`, `AsRef<str>` and maybe `Cow<str>`
 - One can implement `From<CustomType> for AtValue` for their own custom types.
 - Improve `attrs!` macro so it could accept key without a value:
```rust
attrs!{At::Class => "foo", At::Hidden}
```
- `AtValue::None` use case should be handled by value-less attr key
- User should use `AtValue::*` in his code only as a last resort