### PR TITLE
`Vec<Attr>` and `Vec<Style>` in view macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+[unreleased]
+
 ## v0.5.0
 - Added helper `seed::canvas()`, and `seed::canvas_context()` helper functions.
 - Fixed `Url` parsing (resolves issue with hash routing).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 [unreleased]
+- Added support for `Vec<Attr>` and `Vec<Style>` in view macros
 
 ## v0.5.0
 - Added helper `seed::canvas()`, and `seed::canvas_context()` helper functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-[unreleased]
+## v0.5.0
 - Added helper `seed::canvas()`, and `seed::canvas_context()` helper functions.
 - Fixed `Url` parsing (resolves issue with hash routing).
 - [BREAKING] `From<String> for Url` changed to `TryFrom<String> for Url`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ name = "animation_frame"
 version = "0.1.0"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.2",
+ "seed 0.5.0",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -18,7 +18,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "app_builder"
 version = "0.1.0"
 dependencies = [
- "seed 0.4.2",
+ "seed 0.5.0",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -80,7 +80,7 @@ dependencies = [
 name = "canvas"
 version = "0.1.0"
 dependencies = [
- "seed 0.4.2",
+ "seed 0.5.0",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -120,7 +120,7 @@ dependencies = [
 name = "counter"
 version = "0.1.0"
 dependencies = [
- "seed 0.4.2",
+ "seed 0.5.0",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -144,7 +144,7 @@ dependencies = [
 name = "drop"
 version = "0.1.0"
 dependencies = [
- "seed 0.4.2",
+ "seed 0.5.0",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -302,7 +302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "mathjax"
 version = "0.1.0"
 dependencies = [
- "seed 0.4.2",
+ "seed 0.5.0",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -380,7 +380,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "gloo-timers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.2",
+ "seed 0.5.0",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -554,7 +554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "seed"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -607,7 +607,7 @@ name = "server-interaction"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.2",
+ "seed 0.5.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -672,7 +672,7 @@ dependencies = [
 name = "todomvc"
 version = "0.1.0"
 dependencies = [
- "seed 0.4.2",
+ "seed 0.5.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -683,7 +683,7 @@ version = "0.1.0"
 dependencies = [
  "enclose 1.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.2",
+ "seed 0.5.0",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -752,7 +752,7 @@ name = "user_media"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.2",
+ "seed 0.5.0",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -886,7 +886,7 @@ name = "websocket"
 version = "0.1.0"
 dependencies = [
  "js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.2",
+ "seed 0.5.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -935,7 +935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "window-events"
 version = "0.1.0"
 dependencies = [
- "seed 0.4.2",
+ "seed 0.5.0",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seed"
-version = "0.4.2"
+version = "0.5.0"
 description = "A Rust framework for creating web apps, using WebAssembly"
 authors = ["DavidOConnor <david.alan.oconnor@gmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-seed = "^0.4.2"
+seed = "^0.5.0"
 wasm-bindgen = "^0.2.50"
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 
-## [New homepage](https://seed-rs.org), as of November 2019
+## [New homepage](https://seed-rs.org), as of Nov 2019 - We are looking forward to your [feedback](https://github.com/seed-rs/seed/issues/303)!
 
 The best place to learn is the guide on the homepage - this readme is an excerpt from it.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn render() {
-    seed::App::build(|_, _| Init::new(Model::default()), update, view)
+    App::builder(update, view)
         .build_and_start();
 }
 ```

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -5,6 +5,7 @@ This is a list of steps to complete when making a new release.
 1. Review the commit and PR history since last release. Ensure that all relevant
 changes are included in `CHANGELOG.md`, and that breaking changes
 are specifically annotated
+1. Update the version of seed dependency in the readme.
 1. Ensure both the readme and homepage website reflect API changes. Instructions
 for updating the homepage are available [here](https://github.com/seed-rs/seed-homepage)
 1. Update the homepage with the new release version (main page), and changelog

--- a/examples/server_integration/Cargo.lock
+++ b/examples/server_integration/Cargo.lock
@@ -439,7 +439,7 @@ name = "client"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "seed 0.4.2",
+ "seed 0.5.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared 0.1.0",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1318,7 +1318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "seed"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/dom_types.rs
+++ b/src/dom_types.rs
@@ -79,6 +79,22 @@ impl<Ms> UpdateEl<El<Ms>> for &Attrs {
     }
 }
 
+impl<Ms> UpdateEl<El<Ms>> for Vec<Attrs> {
+    fn update(self, el: &mut El<Ms>) {
+        for at in self {
+            el.attrs.merge(at);
+        }
+    }
+}
+
+impl<Ms> UpdateEl<El<Ms>> for Vec<&Attrs> {
+    fn update(self, el: &mut El<Ms>) {
+        for at in self {
+            el.attrs.merge(at.clone());
+        }
+    }
+}
+
 impl<Ms> UpdateEl<El<Ms>> for Style {
     fn update(self, el: &mut El<Ms>) {
         el.style.merge(self);
@@ -88,6 +104,22 @@ impl<Ms> UpdateEl<El<Ms>> for Style {
 impl<Ms> UpdateEl<El<Ms>> for &Style {
     fn update(self, el: &mut El<Ms>) {
         el.style.merge(self.clone());
+    }
+}
+
+impl<Ms> UpdateEl<El<Ms>> for Vec<Style> {
+    fn update(self, el: &mut El<Ms>) {
+        for st in self {
+            el.style.merge(st);
+        }
+    }
+}
+
+impl<Ms> UpdateEl<El<Ms>> for Vec<&Style> {
+    fn update(self, el: &mut El<Ms>) {
+        for st in self {
+            el.style.merge(st.clone());
+        }
     }
 }
 


### PR DESCRIPTION
Could probably expand this to support events, and maps (or filters? Don't remember why we don't have that for child elements) of them.

Example:
```rust
let mut styles = vec![style!{St::Cursor => "pointer"}];
if a {
    styles.push(style!{St::Color => "black"});
}

div![ styles, "text"]
```

Reasoning: Adds more flexibility to the view syntax.