### PR TITLE
Cleaned up Clippy checks

### DIFF
--- a/examples/server_interaction_detailed/src/datetime.rs
+++ b/examples/server_interaction_detailed/src/datetime.rs
@@ -50,12 +50,14 @@ pub struct Date {
 //}
 
 impl PartialEq for Date {
+    #[must_use]
     fn eq(&self, other: &Self) -> bool {
         self.wrapped == other.wrapped
     }
 }
 
 impl PartialOrd for Date {
+    #[must_use]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.wrapped.cmp(&other.wrapped))
     }
@@ -111,20 +113,23 @@ impl fmt::Debug for Date {
 //}
 
 impl From<Cdate> for Date {
+    #[must_use]
     fn from(date: Cdate) -> Self {
         Self { wrapped: date }
     }
 }
 
 impl Date {
+    #[must_use]
     pub fn new(year: i32, month: u32, day: u32) -> Self {
         Self {
             wrapped: chrono::Utc.ymd(year, month, day),
         }
     }
 
-    /// We use js_sys::Date, serialize it, then turn it into a Chrono date, due to limitations
+    /// We use `js_sys::Date`, serialize it, then turn it into a Chrono date, due to limitations
     /// with Crono on the wasm target.
+    #[must_use]
     pub fn today() -> Self {
         let today_js = js_sys::Date::new_0();
 
@@ -139,6 +144,7 @@ impl Date {
     }
 
     /// Convert an iso-format date, eg "2019-01-05" for January 5, 2019" to a Date.
+    #[must_use]
     pub fn from_iso(date: &str) -> Self {
         // Chrono needs time too, and can't parse date-only directly.
         let padded = &(date.to_string() + "T000000");
@@ -151,12 +157,14 @@ impl Date {
     }
 
     // todo operator overload with other being diff type?
+    #[must_use]
     pub fn add(&self, dur: chrono::Duration) -> Self {
         Self {
             wrapped: self.wrapped + dur,
         }
     }
 
+    #[must_use]
     pub fn sub(&self, dur: chrono::Duration) -> Self {
         Self {
             wrapped: self.wrapped - dur,
@@ -164,6 +172,7 @@ impl Date {
     }
 
     /// Getters/setters. Perhaps there's a better way.
+    #[must_use]
     pub fn year(&self) -> u16 {
         self.wrapped
             .year()

--- a/examples/server_interaction_detailed/src/util.rs
+++ b/examples/server_interaction_detailed/src/util.rs
@@ -16,6 +16,7 @@ pub const MX_NE_WX: i8 = 1;
 pub const MX_NE_OPS: i8 = 2;
 pub const MX_NE_MX: i8 = 3;
 
+#[must_use]
 pub fn short_name(person: &Person) -> String {
     format! {"{}, {}", person.last_name, person.first_name}
     // todo first initial.
@@ -31,6 +32,7 @@ fn includes_line(lines: &[Line], line: &Line) -> bool {
     false
 }
 
+#[must_use]
 pub fn formation_lines(selected_line: &Line, lines: &[Line]) -> Vec<Line> {
     // todo sloppy clone (in to_owned)
     let mut sorted_lines = lines.to_owned();
@@ -56,6 +58,7 @@ pub fn formation_lines(selected_line: &Line, lines: &[Line]) -> Vec<Line> {
     current_form
 }
 
+#[must_use]
 pub fn is_aircrew(person: &Person) -> bool {
     person.job == PILOT_JOB || person.job == WSO_JOB
 }

--- a/examples/update_from_js/src/lib.rs
+++ b/examples/update_from_js/src/lib.rs
@@ -62,6 +62,7 @@ fn view(model: &Model) -> Node<Msg> {
 // Start
 
 #[wasm_bindgen]
+#[must_use]
 // `wasm-bindgen` cannot transfer struct with public closures to JS (yet) so we have to send slice.
 pub fn start() -> Box<[JsValue]> {
     let app = seed::App::builder(update, view).build_and_start();

--- a/examples/websocket/src/server.rs
+++ b/examples/websocket/src/server.rs
@@ -30,7 +30,7 @@ impl Handler for Server {
         self.out.broadcast(server_msg)
     }
 
-    fn on_request(&mut self, req: &Request) -> Result<(Response)> {
+    fn on_request(&mut self, req: &Request) -> Result<Response> {
         match req.resource() {
             "/ws" => Response::from_request(req),
             _ => Ok(Response::new(

--- a/src/app.rs
+++ b/src/app.rs
@@ -135,11 +135,11 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
     /// by the state change.
     ///
     /// We re-create the whole virtual dom each time (Is there a way around this? Probably not without
-    /// knowing what vars the model holds ahead of time), but only edit the rendered, web_sys dom
+    /// knowing what vars the model holds ahead of time), but only edit the rendered, `web_sys` dom
     /// for things that have been changed.
     /// We re-render the virtual DOM on every change, but (attempt to) only change
-    /// the actual DOM, via web_sys, when we need.
-    /// The model stored in inner is the old model; updated_model is a newly-calculated one.
+    /// the actual DOM, via `web_sys`, when we need.
+    /// The model stored in inner is the old model; `updated_model` is a newly-calculated one.
     pub fn update(&self, message: Ms) {
         let mut queue: VecDeque<Effect<Ms, GMs>> = VecDeque::new();
         queue.push_front(message.into());

--- a/src/browser/service/fetch.rs
+++ b/src/browser/service/fetch.rs
@@ -109,7 +109,7 @@ pub struct RequestController {
 impl RequestController {
     /// Abort request and disable request's timeout.
     ///
-    /// https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort)
     pub fn abort(&self) {
         // Cancel timeout by dropping it.
         self.timeout_handle.replace(None);
@@ -311,7 +311,7 @@ impl Request {
     /// Set the HTTP method.
     /// Default is GET.
     ///
-    /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods)
     pub const fn method(mut self, method: Method) -> Self {
         self.method = method;
         self
@@ -320,7 +320,7 @@ impl Request {
     /// Add a single header.
     /// String multiple calls to this together to add multiple ones.
     ///
-    /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers)
     pub fn header(mut self, name: &str, value: &str) -> Self {
         self.headers.insert(name.into(), value.into());
         self
@@ -347,43 +347,43 @@ impl Request {
             .body_json(data)
     }
 
-    /// https://developer.mozilla.org/en-US/docs/Web/API/Request/cache
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache)
     pub fn cache(mut self, cache: web_sys::RequestCache) -> Self {
         self.cache = Some(cache);
         self
     }
 
-    /// https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
     pub fn credentials(mut self, request_credentials: web_sys::RequestCredentials) -> Self {
         self.credentials = Some(request_credentials);
         self
     }
 
-    /// https://developer.mozilla.org/en-US/docs/Web/API/Request/integrity
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Request/integrity)
     pub fn integrity(mut self, integrity: &str) -> Self {
         self.integrity = Some(integrity.into());
         self
     }
 
-    /// https://developer.mozilla.org/en-US/docs/Web/API/Request/mode
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode)
     pub fn mode(mut self, mode: web_sys::RequestMode) -> Self {
         self.mode = Some(mode);
         self
     }
 
-    /// https://developer.mozilla.org/en-US/docs/Web/API/Request/redirect
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Request/redirect)
     pub fn redirect(mut self, redirect: web_sys::RequestRedirect) -> Self {
         self.redirect = Some(redirect);
         self
     }
 
-    /// https://developer.mozilla.org/en-US/docs/Web/API/Request/referrer
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Request/referrer)
     pub fn referrer(mut self, referrer: String) -> Self {
         self.referrer = Some(referrer);
         self
     }
 
-    /// https://developer.mozilla.org/en-US/docs/Web/API/Request/referrerPolicy
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Request/referrerPolicy)
     pub fn referrer_policy(mut self, referrer_policy: web_sys::ReferrerPolicy) -> Self {
         self.referrer_policy = Some(referrer_policy);
         self
@@ -426,7 +426,7 @@ impl Request {
     /// if you want to get body data, you have to use field `raw` to get raw `web_sys::Response`.
     /// (Or use methods like `fetch_string` / `fetch_json`.)
     ///
-    /// https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)
     ///
     /// # Example
     ///
@@ -457,7 +457,7 @@ impl Request {
     }
 
     /// Same as method `fetch`, but try to convert body to `String` and insert it into `Response` field `data`.
-    /// https://developer.mozilla.org/en-US/docs/Web/API/Body/text
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Body/text]
     pub async fn fetch_string<U>(self, f: impl FnOnce(FetchObject<String>) -> U) -> Result<U, U>
     where
         U: 'static,
@@ -519,7 +519,7 @@ impl Request {
     }
 
     /// Fetch and then convert body to `String`. It passes `ResponseDataResult<String>` into callback `f`.
-    /// https://developer.mozilla.org/en-US/docs/Web/API/Body/text
+    /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Body/text)
     pub fn fetch_string_data<U>(
         self,
         f: impl FnOnce(ResponseDataResult<String>) -> U,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,11 @@
 //! See readme for details.
 
 //#![deny(missing_docs)]
-#![allow(clippy::use_self, clippy::single_match_else)]
+#![allow(
+    clippy::use_self,
+    clippy::single_match_else,
+    clippy::must_use_candidate
+)]
 #![allow(deprecated)] // @TODO delete once `seed::update` and related things are removed
 
 // @TODO move to prelude (?)

--- a/src/virtual_dom/listener.rs
+++ b/src/virtual_dom/listener.rs
@@ -86,7 +86,7 @@ impl<Ms> Listener<Ms> {
         }
     }
 
-    /// Similar to new_control, but for checkboxes
+    /// Similar to `new_control`, but for checkboxes
     pub fn new_control_check(checked: bool) -> Self {
         Self {
             trigger: Ev::Click,

--- a/src/virtual_dom/node.rs
+++ b/src/virtual_dom/node.rs
@@ -61,7 +61,7 @@ impl<Ms> Node<Ms> {
         self
     }
 
-    /// /// See `El::add_class``
+    /// See `El::add_class`
     pub fn add_class(&mut self, name: impl Into<Cow<'static, str>>) -> &mut Self {
         if let Node::Element(el) = self {
             el.add_class(name);


### PR DESCRIPTION
The `must_use` lint seems a little... aggressive. Disabled it for the main repo. CI is still failing for examples. I don't want to add either this tag, or the allow to examples; maybe we can use normal `clippy` instead of `clippy::pedantic` in the examples.