### PR TITLE
Fixed custom elements patching, Added El::is_custom()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 [unreleased]
 
 - Implemented `UpdateEl` for `Filter` and `FilterMap`.
+- Added method `El::is_custom(&self)`.
+- Fixed custom elements patching (#325).
 
 ## v0.5.1
 - [BREAKING] `MessageMapper::map_message` changed to `MessageMapper::map_msg`.

--- a/src/virtual_dom/node/el.rs
+++ b/src/virtual_dom/node/el.rs
@@ -201,6 +201,16 @@ impl<Ms> El<Ms> {
             child.strip_ws_nodes_from_self_and_children();
         }
     }
+
+    /// Is it a custom element?
+    pub fn is_custom(&self) -> bool {
+        // @TODO: replace with `matches!` macro once stable
+        if let Tag::Custom(_) = self.tag {
+            true
+        } else {
+            false
+        }
+    }
 }
 
 /// Allow the user to clone their Els. Note that there's no easy way to clone the

--- a/src/virtual_dom/patch.rs
+++ b/src/virtual_dom/patch.rs
@@ -127,8 +127,9 @@ fn patch_el<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
         // old el vdom's elements are still attached.
 
         // Namespaces can't be patched, since they involve create_element_ns instead of create_element.
+        // Custom elements can't be patched, because we need to reinit them (Issue #325). (@TODO is there a better way?)
         // Something about this element itself is different: patch it.
-        if old.tag != new.tag || old.namespace != new.namespace {
+        if old.tag != new.tag || old.namespace != new.namespace || old.is_custom() {
             let old_el_ws = old.node_ws.as_ref().expect("Missing websys el");
 
             // We don't use assign_nodes directly here, since we only have access to


### PR DESCRIPTION
https://github.com/seed-rs/seed/issues/325

Custom elements (like `code-block` on `seed-rs.org`) have to be recreated, we cannot manage their content directly (i.e. we can't patch them like the built-in elements).

We should try to find a better solution and write tests once there is a solid Rust wrapper for WebComponents.

Tested with `seed-rs.org` project connected to modified local Seed repository.