### PR TITLE
Removed unnecessary error message for comment nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Implemented `UpdateEl` for `Filter` and `FilterMap`.
 - Added method `El::is_custom(&self)`.
 - Fixed custom elements patching (#325).
+- Removed unnecessary error message for comment nodes.
 
 ## v0.5.1
 - [BREAKING] `MessageMapper::map_message` changed to `MessageMapper::map_msg`.

--- a/src/browser/dom/virtual_dom_bridge.rs
+++ b/src/browser/dom/virtual_dom_bridge.rs
@@ -447,8 +447,12 @@ pub fn node_from_ws<Ms>(node: &web_sys::Node) -> Option<Node<Ms>> {
         web_sys::Node::TEXT_NODE => Some(Node::new_text(
             node.text_content().expect("Can't find text"),
         )),
-        _ => {
-            crate::error("Unexpected node type found from raw html");
+        web_sys::Node::COMMENT_NODE => None,
+        node_type => {
+            crate::error(format!(
+                "HTML node type {} is not supported by Seed",
+                node_type
+            ));
             None
         }
     }


### PR DESCRIPTION
There was a problem with comments in mount points (when you are also using `MountType::Takeover`) or when you want to use `raw!` macro.

Bug example: https://realworld.seed-rs.org/ - see console log - `"Unexpected node type found from raw html"`. Comment that causes the error - https://github.com/seed-rs/seed-rs-realworld/blob/a72c331f1cf53d55e71445c0f00552df513e12b1/index.html#L15. 