### PR TITLE
impl Clone manually for EventHandler<Ms>

### DIFF
--- a/src/virtual_dom/event_handler_manager/event_handler.rs
+++ b/src/virtual_dom/event_handler_manager/event_handler.rs
@@ -2,11 +2,19 @@ use crate::app::MessageMapper;
 use crate::virtual_dom::Ev;
 use std::{fmt, rc::Rc};
 
-#[derive(Clone)]
 /// `EventHandler`s are called by DOM event listeners with the same trigger (an event to listen to).
 pub struct EventHandler<Ms> {
     pub trigger: Ev,
     pub callback: Rc<dyn Fn(web_sys::Event) -> Ms>,
+}
+
+impl<Ms> Clone for EventHandler<Ms> {
+    fn clone(&self) -> Self {
+        Self {
+            trigger: self.trigger.clone(),
+            callback: self.callback.clone(),
+        }
+    }
 }
 
 impl<Ms> EventHandler<Ms> {

--- a/src/virtual_dom/event_handler_manager/event_handler.rs
+++ b/src/virtual_dom/event_handler_manager/event_handler.rs
@@ -8,11 +8,12 @@ pub struct EventHandler<Ms> {
     pub callback: Rc<dyn Fn(web_sys::Event) -> Ms>,
 }
 
+// @TODO remove custom impl once https://github.com/rust-lang/rust/issues/26925 is fixed
 impl<Ms> Clone for EventHandler<Ms> {
     fn clone(&self) -> Self {
         Self {
             trigger: self.trigger.clone(),
-            callback: self.callback.clone(),
+            callback: Rc::clone(&self.callback),
         }
     }
 }


### PR DESCRIPTION
the current implementation does require `Ms` to impl `Clone` :D
https://doc.rust-lang.org/stable/std/clone/trait.Clone.html#derivable