### PR TITLE
Feat/flat map and remove clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added a new simpler `counter` example.
 - Changed example in the main `README.md`.
 - Added flag `#![forbid(unsafe_code)]` so the Seed will be marked as a safe library by the Rust community tools.
+- Removed `clone` restriction from the method `Effect::map_msg`.
 
 ## v0.5.1
 - [BREAKING] `MessageMapper::map_message` changed to `MessageMapper::map_msg`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Changed example in the main `README.md`.
 - Added flag `#![forbid(unsafe_code)]` so the Seed will be marked as a safe library by the Rust community tools.
 - Removed `clone` restriction from the method `Effect::map_msg`.
+- Implemented `UpdateEl` for `FlatMap`.
 
 ## v0.5.1
 - [BREAKING] `MessageMapper::map_message` changed to `MessageMapper::map_msg`.

--- a/src/virtual_dom/update_el.rs
+++ b/src/virtual_dom/update_el.rs
@@ -167,3 +167,15 @@ where
         self.for_each(|item| item.update(el));
     }
 }
+
+impl<Ms, I, U, F, II> UpdateEl<El<Ms>> for std::iter::FlatMap<I, II, F>
+where
+    I: Iterator,
+    U: UpdateEl<El<Ms>>,
+    II: IntoIterator<Item = U>,
+    F: FnMut(I::Item) -> II,
+{
+    fn update(self, el: &mut El<Ms>) {
+        self.for_each(|item| item.update(el));
+    }
+}


### PR DESCRIPTION
Implemented `UpdateEl` for `FlatMap`, so you can write:
```rust
pub fn line_breaked_div(lines: Vec<String>) -> Node<Msg> {
    div![
        lines
            .into_iter()
            .flat_map(|line| vec![Node::new_text(line), br![]])
    ]
}
```

---

Removed one unnecessary cloning and `Clone` constraint.