### PR TITLE
fixes typo Refenences -> References

### DIFF
--- a/src/browser/service/routing.rs
+++ b/src/browser/service/routing.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 
 /// Add a new route using history's `push_state` method.
 ///
-/// # Refenences
+/// # References
 /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/History_API)
 pub fn push_route<U: Into<Url>>(url: U) -> Url {
     let url = url.into();

--- a/src/browser/url.rs
+++ b/src/browser/url.rs
@@ -25,7 +25,7 @@ pub struct Url {
 impl Url {
     /// Helper that ignores hash, search and title, and converts path to Strings.
     ///
-    /// # Refenences
+    /// # References
     /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/History_API)
     pub fn new<T: ToString>(path: Vec<T>) -> Self {
         Self {
@@ -38,7 +38,7 @@ impl Url {
 
     /// Builder-pattern method for defining hash.
     ///
-    /// # Refenences
+    /// # References
     /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/hash)
     pub fn hash(mut self, hash: &str) -> Self {
         self.hash = Some(hash.into());


### PR DESCRIPTION
fixes a small typo I found in the documentation.

Thanks for your awesome work!