### PR TITLE
Fix failing GHA pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           toolchain: stable
 
       - name: Install cargo-make
-        uses: davidB/rust-cargo-make@v1
+        run: cargo install cargo-make
 
       - name: Run tests - Windows or Ubuntu
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'


### PR DESCRIPTION
Note: The latest Cargo doesn't require `--force`