### PR TITLE
UpdateEl refactor + updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - [BREAKING] Changed `perform_cmd` and `fetch` return type to `T` instead of `Result<T, T>`.
 - Added Aria attributes.
 - Added example `tea_component`.
+- [BREAKING] `UpdateEl<T>` changed to `UpdateEl<Ms>` and `fn update(self, el: &mut T);` to `fn update_el(self, el: &mut El<Ms>);` (#370).
+- Added trait `UpdateElForIterator<Ms>`.
+- Added support for all `Iterator`s, `Option`, `u32`, `i32`, `usize`, `f64` and references in element creation macros (#365, #128).
+- [BREAKING] `String` implements `UpdateEl<T>`. (References are now required for `String` properties, e.g. `div![&model.title]`.)
 
 ## v0.6.0
 - Implemented `UpdateEl` for `Filter` and `FilterMap`.

--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -68,7 +68,7 @@ fn view(model: &Model) -> impl View<Msg> {
             St::Height => vmin(50),
         ],
         if model.greet_clicked {
-            h1![model.title]
+            h1![&model.title]
         } else {
             div![
                 style![

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -345,7 +345,7 @@ fn view_todo(
                     Ev::DblClick,
                     enc!((todo_id) move |_| Msg::StartTodoEdit(todo_id))
                 ),
-                todo.title
+                &todo.title
             ],
             button![
                 class!["destroy"],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub mod prelude {
         shortcuts::*,
         virtual_dom::{
             el_ref::el_ref, AsAtValue, At, AtValue, CSSValue, El, ElRef, Ev, EventHandler, Node,
-            St, Tag, UpdateEl, View,
+            St, Tag, UpdateEl, UpdateElForIterator, View,
         },
     };
     pub use indexmap::IndexMap; // for attrs and style to work.

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -30,7 +30,7 @@ macro_rules! element {
                                 #[allow(unused_mut)]
                                 let mut el = El::empty($crate::virtual_dom::Tag::$Tag_camel);
                                 $d (
-                                    $d part.update(&mut el);
+                                    $d part.update_el(&mut el);
                                 )*
                                 $crate::virtual_dom::Node::Element(el)
                             }
@@ -55,7 +55,7 @@ macro_rules! element_svg {
                             {
                                 #[allow(unused_mut)]
                                 let mut el = El::empty_svg($crate::virtual_dom::Tag::$Tag_camel);
-                                $d ( $d part.update(&mut el); )*
+                                $d ( $d part.update_el(&mut el); )*
                                 $crate::virtual_dom::Node::Element(el)
                             }
                         };
@@ -186,7 +186,7 @@ macro_rules! custom {
         {
             let default_tag_name = "missing-tag-name";
             let mut el = El::empty($crate::virtual_dom::Tag::from(default_tag_name));
-            $ ( $part.update(&mut el); )*
+            $ ( $part.update_el(&mut el); )*
 
             if let $crate::virtual_dom::Tag::Custom(tag_name) = &el.tag {
                 let tag_changed = tag_name != default_tag_name;

--- a/src/virtual_dom.rs
+++ b/src/virtual_dom.rs
@@ -15,7 +15,7 @@ pub use event_handler_manager::{EventHandler, EventHandlerManager, Listener};
 pub use mailbox::Mailbox;
 pub use node::{El, IntoNodes, Node, Text};
 pub use style::Style;
-pub use update_el::UpdateEl;
+pub use update_el::{UpdateEl, UpdateElForIterator};
 pub use values::{AsAtValue, AtValue, CSSValue};
 pub use view::View;
 

--- a/src/virtual_dom/update_el.rs
+++ b/src/virtual_dom/update_el.rs
@@ -1,181 +1,391 @@
 use super::{Attrs, El, ElRef, EventHandler, Node, Style, Tag, Text};
 
+// ------ Traits ------
+
 /// `UpdateEl` is used to distinguish arguments in element-creation macros, and handle
 /// each type appropriately.
-pub trait UpdateEl<T> {
-    // T is the type of thing we're updating; eg attrs, style, events etc.
-    fn update(self, el: &mut T);
+pub trait UpdateEl<Ms> {
+    fn update_el(self, el: &mut El<Ms>);
 }
 
-impl<Ms> UpdateEl<El<Ms>> for Attrs {
-    fn update(self, el: &mut El<Ms>) {
+/// Similar to `UpdateEl`, specialized for `Iterator`.
+#[allow(clippy::module_name_repetitions)]
+pub trait UpdateElForIterator<Ms> {
+    fn update_el(self, el: &mut El<Ms>);
+}
+
+// ------ Implementations ------
+
+impl<Ms, T: UpdateEl<Ms> + Clone> UpdateEl<Ms> for &T {
+    fn update_el(self, el: &mut El<Ms>) {
+        self.clone().update_el(el);
+    }
+}
+
+// --- V-DOM entities ---
+
+impl<Ms> UpdateEl<Ms> for Attrs {
+    fn update_el(self, el: &mut El<Ms>) {
         el.attrs.merge(self);
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for &Attrs {
-    fn update(self, el: &mut El<Ms>) {
-        el.attrs.merge(self.clone());
-    }
-}
-
-impl<Ms> UpdateEl<El<Ms>> for Vec<Attrs> {
-    fn update(self, el: &mut El<Ms>) {
-        for at in self {
-            el.attrs.merge(at);
-        }
-    }
-}
-
-impl<Ms> UpdateEl<El<Ms>> for Vec<&Attrs> {
-    fn update(self, el: &mut El<Ms>) {
-        for at in self {
-            el.attrs.merge(at.clone());
-        }
-    }
-}
-
-impl<Ms> UpdateEl<El<Ms>> for Style {
-    fn update(self, el: &mut El<Ms>) {
+impl<Ms> UpdateEl<Ms> for Style {
+    fn update_el(self, el: &mut El<Ms>) {
         el.style.merge(self);
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for &Style {
-    fn update(self, el: &mut El<Ms>) {
-        el.style.merge(self.clone());
-    }
-}
-
-impl<Ms> UpdateEl<El<Ms>> for Vec<Style> {
-    fn update(self, el: &mut El<Ms>) {
-        for st in self {
-            el.style.merge(st);
-        }
-    }
-}
-
-impl<Ms> UpdateEl<El<Ms>> for Vec<&Style> {
-    fn update(self, el: &mut El<Ms>) {
-        for st in self {
-            el.style.merge(st.clone());
-        }
-    }
-}
-
-impl<Ms> UpdateEl<El<Ms>> for EventHandler<Ms> {
-    fn update(self, el: &mut El<Ms>) {
+impl<Ms> UpdateEl<Ms> for EventHandler<Ms> {
+    fn update_el(self, el: &mut El<Ms>) {
         el.event_handler_manager.add_event_handlers(vec![self])
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for Vec<EventHandler<Ms>> {
-    fn update(self, el: &mut El<Ms>) {
-        el.event_handler_manager.add_event_handlers(self);
-    }
-}
-
-impl<Ms> UpdateEl<El<Ms>> for &str {
-    fn update(self, el: &mut El<Ms>) {
-        el.children.push(Node::Text(Text::new(self.to_string())))
-    }
-}
-
-// In the most cases `&str` is enough,
-// but if we have, for instance, `Filter` iterator of `String`s -
-// then the Rust type system can't coerce `String` to `&str`.
-//
-// However if we implement `UpdateEl` for `String`, code like `h1![model.title]` cannot be compiled,
-// because Rust chooses `String` impl instead of `&str` and fails on moving value (`title`).
-// @TODO How to resolve it? `&self`?
-//
-//impl<Ms> UpdateEl<El<Ms>> for String {
-//    fn update(self, el: &mut El<Ms>) {
-//        el.children.push(Node::Text(Text::new(self)))
-//    }
-//}
-
-impl<Ms> UpdateEl<El<Ms>> for El<Ms> {
-    fn update(self, el: &mut El<Ms>) {
+impl<Ms> UpdateEl<Ms> for El<Ms> {
+    fn update_el(self, el: &mut El<Ms>) {
         el.children.push(Node::Element(self))
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for Vec<El<Ms>> {
-    fn update(self, el: &mut El<Ms>) {
-        el.children
-            .append(&mut self.into_iter().map(Node::Element).collect());
-    }
-}
-
-impl<Ms> UpdateEl<El<Ms>> for Node<Ms> {
-    fn update(self, el: &mut El<Ms>) {
+impl<Ms> UpdateEl<Ms> for Node<Ms> {
+    fn update_el(self, el: &mut El<Ms>) {
         el.children.push(self)
     }
 }
 
-impl<Ms> UpdateEl<El<Ms>> for Vec<Node<Ms>> {
-    fn update(mut self, el: &mut El<Ms>) {
-        el.children.append(&mut self);
-    }
-}
-
-/// This is intended only to be used for the custom! element macro.
-impl<Ms> UpdateEl<El<Ms>> for Tag {
-    fn update(self, el: &mut El<Ms>) {
+/// This is intended only to be used for the `custom!` element macro.
+impl<Ms> UpdateEl<Ms> for Tag {
+    fn update_el(self, el: &mut El<Ms>) {
         el.tag = self;
     }
 }
 
-impl<Ms, E: Clone> UpdateEl<El<Ms>> for ElRef<E> {
-    fn update(self, el: &mut El<Ms>) {
+impl<Ms, E: Clone> UpdateEl<Ms> for ElRef<E> {
+    fn update_el(self, el: &mut El<Ms>) {
         el.refs.push(self.shared_node_ws);
     }
 }
 
-// ----- Iterators ------
+// --- Texts ---
 
-impl<Ms, I, U, F> UpdateEl<El<Ms>> for std::iter::Map<I, F>
-where
-    I: Iterator,
-    U: UpdateEl<El<Ms>>,
-    F: FnMut(I::Item) -> U,
-{
-    fn update(self, el: &mut El<Ms>) {
-        self.for_each(|item| item.update(el));
+impl<Ms> UpdateEl<Ms> for String {
+    fn update_el(self, el: &mut El<Ms>) {
+        el.children.push(Node::Text(Text::new(self)))
     }
 }
 
-impl<Ms, I, U, F> UpdateEl<El<Ms>> for std::iter::FilterMap<I, F>
-where
-    I: Iterator,
-    U: UpdateEl<El<Ms>>,
-    F: FnMut(I::Item) -> Option<U>,
-{
-    fn update(self, el: &mut El<Ms>) {
-        self.for_each(|item| item.update(el));
+impl<Ms> UpdateEl<Ms> for &str {
+    fn update_el(self, el: &mut El<Ms>) {
+        el.children.push(Node::Text(Text::new(self.to_string())))
     }
 }
 
-impl<Ms, I, U, P> UpdateEl<El<Ms>> for std::iter::Filter<I, P>
-where
-    U: UpdateEl<El<Ms>>,
-    I: Iterator<Item = U>,
-    P: FnMut(&I::Item) -> bool,
-{
-    fn update(self, el: &mut El<Ms>) {
-        self.for_each(|item| item.update(el));
+// --- Numbers ---
+
+impl<Ms> UpdateEl<Ms> for u32 {
+    fn update_el(self, el: &mut El<Ms>) {
+        self.to_string().update_el(el);
     }
 }
 
-impl<Ms, I, U, F, II> UpdateEl<El<Ms>> for std::iter::FlatMap<I, II, F>
-where
-    I: Iterator,
-    U: UpdateEl<El<Ms>>,
-    II: IntoIterator<Item = U>,
-    F: FnMut(I::Item) -> II,
-{
-    fn update(self, el: &mut El<Ms>) {
-        self.for_each(|item| item.update(el));
+impl<Ms> UpdateEl<Ms> for i32 {
+    fn update_el(self, el: &mut El<Ms>) {
+        self.to_string().update_el(el);
+    }
+}
+
+impl<Ms> UpdateEl<Ms> for usize {
+    fn update_el(self, el: &mut El<Ms>) {
+        self.to_string().update_el(el);
+    }
+}
+
+impl<Ms> UpdateEl<Ms> for f64 {
+    fn update_el(self, el: &mut El<Ms>) {
+        self.to_string().update_el(el);
+    }
+}
+
+// --- Containers ---
+
+impl<Ms, T: UpdateEl<Ms>, I: Iterator<Item = T>> UpdateElForIterator<Ms> for I {
+    fn update_el(self, el: &mut El<Ms>) {
+        for item in self {
+            item.update_el(el);
+        }
+    }
+}
+
+impl<Ms, T: UpdateEl<Ms>> UpdateEl<Ms> for Option<T> {
+    fn update_el(self, el: &mut El<Ms>) {
+        self.into_iter().update_el(el)
+    }
+}
+
+impl<Ms, T: UpdateEl<Ms>> UpdateEl<Ms> for Vec<T> {
+    fn update_el(self, el: &mut El<Ms>) {
+        self.into_iter().update_el(el)
+    }
+}
+
+impl<Ms, T: UpdateEl<Ms> + Clone> UpdateEl<Ms> for &[T] {
+    fn update_el(self, el: &mut El<Ms>) {
+        self.iter().update_el(el)
+    }
+}
+
+// ------ Tests ------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prelude::*;
+    use wasm_bindgen_test::*;
+
+    type Ms = ();
+
+    // @TODO:
+    // These tests only check types.
+    // Verify also HTML once https://github.com/seed-rs/seed/issues/294 is resolved.
+    // DRY
+
+    // --- V-DOM entities ---
+
+    #[wasm_bindgen_test]
+    fn update_el_attrs() {
+        let attrs: Attrs = attrs!(At::Href => "https://example.com");
+        let _el: Node<Ms> = div![attrs];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_attrs() {
+        let attrs: &Attrs = &attrs!(At::Href => "https://example.com");
+        let _el: Node<Ms> = div![attrs];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_style() {
+        let style: Style = style! {St::Left => px(5)};
+        let _el: Node<Ms> = div![style];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_style() {
+        let style: &Style = &style! {St::Left => px(5)};
+        let _el: Node<Ms> = div![style];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_event_handler() {
+        let event_handler: EventHandler<Ms> = ev(Ev::Click, |_| ());
+        let _el: Node<Ms> = div![event_handler];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_event_handler() {
+        let event_handler: &EventHandler<Ms> = &ev(Ev::Click, |_| ());
+        let _el: Node<Ms> = div![event_handler];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_el() {
+        let el: El<Ms> = El::empty(Tag::H2);
+        let _el: Node<Ms> = div![el];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_el() {
+        let el: &El<Ms> = &El::empty(Tag::H2);
+        let _el: Node<Ms> = div![el];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_node() {
+        let node: Node<Ms> = span![];
+        let _el: Node<Ms> = div![node];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_node() {
+        let node: &Node<Ms> = &span![];
+        let _el: Node<Ms> = div![node];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_tag() {
+        let tag: Tag = Tag::H1;
+        let _el: Node<Ms> = div![tag];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_tag() {
+        let tag: &Tag = &Tag::H1;
+        let _el: Node<Ms> = div![tag];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_el_ref() {
+        let el_ref: ElRef<web_sys::HtmlElement> = ElRef::default();
+        let _el: Node<Ms> = div![el_ref];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_el_ref() {
+        let el_ref: &ElRef<web_sys::HtmlElement> = &ElRef::default();
+        let _el: Node<Ms> = div![el_ref];
+        assert!(true);
+    }
+
+    // --- Texts ---
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_str() {
+        let text: &str = "foo";
+        let _el: Node<Ms> = div![text];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_string() {
+        let text: String = String::from("bar");
+        let _el: Node<Ms> = div![text];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_string() {
+        let text: &String = &String::from("ref_bar");
+        let _el: Node<Ms> = div![text];
+        assert!(true);
+    }
+
+    // --- Numbers ---
+
+    #[wasm_bindgen_test]
+    fn update_el_u32() {
+        let number: u32 = 100;
+        let _el: Node<Ms> = div![number];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_u32() {
+        let number: &u32 = &1009;
+        let _el: Node<Ms> = div![number];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_i32() {
+        let number: i32 = -25;
+        let _el: Node<Ms> = div![number];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_i32() {
+        let number: &i32 = &-259;
+        let _el: Node<Ms> = div![number];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_usize() {
+        let number: usize = 1_012;
+        let _el: Node<Ms> = div![number];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_usize() {
+        let number: &usize = &10_129;
+        let _el: Node<Ms> = div![number];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_f64() {
+        let number: f64 = 3.14;
+        let _el: Node<Ms> = div![number];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_f64() {
+        let number: &f64 = &3.149;
+        let _el: Node<Ms> = div![number];
+        assert!(true);
+    }
+
+    // --- Containers ---
+
+    #[wasm_bindgen_test]
+    fn update_el_iterator_map() {
+        let map_iterator = vec![3, 4].into_iter().map(|n| n * 2);
+        let _el: Node<Ms> = div![map_iterator];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_iterator_filter() {
+        let filter_iterator = vec![3, 4].into_iter().filter(|n| n % 2 == 1);
+        let _el: Node<Ms> = div![filter_iterator];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_vec() {
+        let vec: Vec<&str> = vec!["foo_1", "foo_2"];
+        let _el: Node<Ms> = div![vec];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_vec() {
+        let vec: &Vec<&str> = &vec!["foo_1", "foo_2"];
+        let _el: Node<Ms> = div![vec];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_slice() {
+        let slice: &[&str] = &["foo_1", "foo_2"];
+        let _el: Node<Ms> = div![slice];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_option_some() {
+        let option: Option<&str> = Some("foo_opt");
+        let _el: Node<Ms> = div![option];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_ref_option_some() {
+        let option: &Option<&str> = &Some("foo_opt");
+        let _el: Node<Ms> = div![option];
+        assert!(true);
+    }
+
+    #[wasm_bindgen_test]
+    fn update_el_option_none() {
+        let option: Option<&str> = None;
+        let _el: Node<Ms> = div![option];
+        assert!(true);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/seed-rs/seed/issues/370.
Resolves https://github.com/seed-rs/seed/issues/365.
Resolves https://github.com/seed-rs/seed/issues/128.

Changelog:
- [BREAKING] `UpdateEl<T>` changed to `UpdateEl<Ms>` and `fn update(self, el: &mut T);` to `fn update_el(self, el: &mut El<Ms>);`.
- Added trait `UpdateElForIterator<Ms>`.
- Added support for all `Iterator`s, `Option`, `u32`, `i32`, `usize`, `f64` and references in element creation macros.