### PR TITLE
App::start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - [BREAKING] Url change listeners are always active (even if `routes` is not defined).
 - Added `cmds`, `streams`, `subs`, `CmdHandle`, `SubHandle` and `StreamHandle` into the Seed's prelude.
 - [BREAKING] Removed module `next_tick`.
+- Added method `App::start` (alternative to `AppBuilder`) (#376, #382).
+- Added trait `GetElemnt` + included in the `prelude` (alternative to `MountPoint`, used in `AppStart`).
+- Updated example `subscribe` to use `App::start`.
 
 ## v0.6.0
 - Implemented `UpdateEl` for `Filter` and `FilterMap`.

--- a/examples/server_integration/client/src/example_e.rs
+++ b/examples/server_integration/client/src/example_e.rs
@@ -93,7 +93,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         }
         Msg::AnswerChanged => toggle(&mut model.form_mut().answer),
         Msg::FormSubmitted(id) => {
-            let form = take(model.form_mut());
+            let form = mem::take(model.form_mut());
             orders.perform_cmd(send_request(form.to_form_data().unwrap()));
             *model = Model::WaitingForResponse(form);
             log!(format!("Form {} submitted.", id));
@@ -108,7 +108,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             log_1(&response_data.into());
         }
         Msg::ServerResponded(Err(fail_reason)) => {
-            *model = Model::ReadyToSubmit(take(model.form_mut()));
+            *model = Model::ReadyToSubmit(mem::take(model.form_mut()));
             error!("Request failed!", fail_reason);
         }
     }
@@ -131,10 +131,6 @@ fn clear_file_input() {
             // Note: `file_input.set_files(None)` doesn't work
             file_input.set_value("")
         });
-}
-
-fn take<T: Default>(source: &mut T) -> T {
-    mem::replace(source, T::default())
 }
 
 fn toggle(value: &mut bool) {

--- a/src/app/get_element.rs
+++ b/src/app/get_element.rs
@@ -1,0 +1,31 @@
+use crate::browser::util::document;
+use web_sys::{Element, HtmlElement};
+
+pub trait GetElement {
+    /// Returns wrapped `web_sys::Element` or tries to get one from the DOM.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the element cannot be found.
+    fn get_element(self) -> Result<Element, String>;
+}
+
+impl GetElement for &str {
+    fn get_element(self) -> Result<Element, String> {
+        document()
+            .get_element_by_id(self)
+            .ok_or_else(|| format!("cannot find element with given id: {}", self))
+    }
+}
+
+impl GetElement for Element {
+    fn get_element(self) -> Result<Element, String> {
+        Ok(self)
+    }
+}
+
+impl GetElement for HtmlElement {
+    fn get_element(self) -> Result<Element, String> {
+        Ok(self.into())
+    }
+}

--- a/src/app/subs.rs
+++ b/src/app/subs.rs
@@ -8,7 +8,6 @@ pub use url_requested::UrlRequested;
 // ------ UrlChanged sub ------
 
 /// Subscribe to url changes.
-/// - Url change is fired also on application start by default.
 ///
 /// # Example
 ///

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -2,6 +2,7 @@ use super::OrdersContainer;
 use crate::browser::Url;
 use crate::virtual_dom::EventHandler;
 
+pub type InitFn<Ms, Mdl, ElC, GMs> = fn(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Mdl;
 pub type UpdateFn<Ms, Mdl, ElC, GMs> = fn(Ms, &mut Mdl, &mut OrdersContainer<Ms, Mdl, ElC, GMs>);
 pub type SinkFn<Ms, Mdl, ElC, GMs> = fn(GMs, &mut Mdl, &mut OrdersContainer<Ms, Mdl, ElC, GMs>);
 pub type ViewFn<Mdl, ElC> = fn(&Mdl) -> ElC;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,8 @@ pub mod prelude {
     pub use crate::{
         app::{
             builder::init::Init, cmds, streams, subs, AfterMount, App, BeforeMount, CmdHandle,
-            MessageMapper, MountType, Orders, RenderTimestampDelta, StreamHandle, SubHandle,
-            UrlHandling,
+            GetElement, MessageMapper, MountType, Orders, RenderTimestampDelta, StreamHandle,
+            SubHandle, UrlHandling,
         },
         browser::dom::css_units::*,
         browser::dom::event_handler::{


### PR DESCRIPTION
Changes

- Added method `App::start` (alternative to `AppBuilder`) (#376, #382).
- Added trait `GetElemnt` + included in the `prelude` (alternative to `MountPoint`, used in `AppStart`).
- Updated example `subscribe` to use `App::start`.