### PR TITLE
Remove 'static for Node and El

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,10 @@ jobs:
           profile: minimal
           toolchain: stable
 
+      # @TODO remove once https://github.com/rustwasm/wasm-pack/pull/819 released
+      - name: Install wasm-pack
+        run: cargo install --git https://github.com/dalcde/wasm-pack
+
       - name: Install cargo-make
         run: cargo install cargo-make
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 [unreleased]
+- Removed `'static` bound from `El` and `Node`.
 - [BREAKING] Changed `perform_cmd` and `fetch` return type to `T` instead of `Result<T, T>`.
 - Added Aria attributes.
 - Added example `tea_component`.

--- a/src/browser/dom/virtual_dom_bridge.rs
+++ b/src/browser/dom/virtual_dom_bridge.rs
@@ -25,10 +25,7 @@ pub(crate) fn assign_ws_nodes_to_el<Ms>(document: &Document, el: &mut El<Ms>) {
     }
 }
 /// Recursively create `web_sys::Node`s, and place them in the vdom Nodes' fields.
-pub(crate) fn assign_ws_nodes<Ms>(document: &Document, node: &mut Node<Ms>)
-where
-    Ms: 'static,
-{
+pub(crate) fn assign_ws_nodes<Ms>(document: &Document, node: &mut Node<Ms>) {
     match node {
         Node::Element(el) => assign_ws_nodes_to_el(document, el),
         Node::Text(text) => {

--- a/src/virtual_dom/node.rs
+++ b/src/virtual_dom/node.rs
@@ -15,7 +15,7 @@ pub use text::Text;
 /// [`web_sys` reference](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Node.html)
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
-pub enum Node<Ms: 'static> {
+pub enum Node<Ms> {
     Element(El<Ms>),
     //    Svg(El<Ms>),  // May be best to handle using namespace field on El
     Text(Text),

--- a/src/virtual_dom/node/el.rs
+++ b/src/virtual_dom/node/el.rs
@@ -16,7 +16,7 @@ use std::borrow::Cow;
 /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Element)
 /// [`web_sys` reference](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Element.html)
 #[derive(Debug)] // todo: Custom debug implementation where children are on new lines and indented.
-pub struct El<Ms: 'static> {
+pub struct El<Ms> {
     // Ms is a message type, as in part of TEA.
     // We call this 'El' instead of 'Element' for brevity, and to prevent
     // confusion with web_sys::Element.

--- a/src/virtual_dom/view.rs
+++ b/src/virtual_dom/view.rs
@@ -1,6 +1,6 @@
 use super::{El, Node};
 
-pub trait View<Ms: 'static> {
+pub trait View<Ms> {
     fn els(self) -> Vec<Node<Ms>>;
 }
 
@@ -16,13 +16,13 @@ impl<Ms> View<Ms> for Vec<El<Ms>> {
     }
 }
 
-impl<Ms: 'static> View<Ms> for Node<Ms> {
+impl<Ms> View<Ms> for Node<Ms> {
     fn els(self) -> Vec<Node<Ms>> {
         vec![self]
     }
 }
 
-impl<Ms: 'static> View<Ms> for Vec<Node<Ms>> {
+impl<Ms> View<Ms> for Vec<Node<Ms>> {
     fn els(self) -> Vec<Node<Ms>> {
         self
     }


### PR DESCRIPTION
Resolves #394 

- Removes `'static` bound on `El` and `Node`.
- Fixes failing CI.

Based on https://github.com/seed-rs/seed/pull/395.