### PR TITLE
Handlers accept Msg or ()

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,6 @@ jobs:
           profile: minimal
           toolchain: stable
 
-      # @TODO remove once https://github.com/rustwasm/wasm-pack/pull/819 released
-      - name: Install wasm-pack
-        run: cargo install --git https://github.com/dalcde/wasm-pack
-
       - name: Install cargo-make
         run: cargo install cargo-make
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Updated `todomvc` example to use `C!`, `IF!`, `matches!` and `App::start`.
 - `ev` accepts handlers which return `Msg` and `()` (#394).
 - [BREAKING] `EventHandler::new` accepts only handlers which return `Option<Msg>`.
-- [BREAKING] `ev`-like functions require `'static` bound for generic types (temporary). 
+- [BREAKING] `ev`-like functions and some `Orders` method require `'static` bound for generic types (temporary). 
 - `Orders::after_next_render` now accepts callbacks with returns `Msg` or `()`.
 - Updated examples `update_from_js` and `todomvc`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 - `ev` accepts handlers which return `Msg` and `()` (#394).
 - [BREAKING] `EventHandler::new` accepts only handlers which return `Option<Msg>`.
 - [BREAKING] `ev`-like functions require `'static` bound for generic types (temporary). 
+- `Orders::after_next_render` now accepts callbacks with returns `Msg` or `()`.
+- Updated examples `update_from_js` and `todomvc`.
 
 ## v0.6.0
 - Implemented `UpdateEl` for `Filter` and `FilterMap`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - `ev` accepts handlers which return `Msg` and `()` (#394).
 - [BREAKING] `EventHandler::new` accepts only handlers which return `Option<Msg>`.
 - [BREAKING] `ev`-like functions and some `Orders` method require `'static` bound for generic types (temporary). 
-- `Orders::after_next_render` now accepts callbacks with returns `Msg` or `()`.
+- `Orders::after_next_render` now accepts callbacks which return `Msg` or `()`.
 - Updated examples `update_from_js` and `todomvc`.
 
 ## v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 - Added macros `C!` and `IF!` and helper `not` (#375).
 - Added trait `ToClasses` + included in the `prelude`.
 - Updated `todomvc` example to use `C!`, `IF!`, `matches!` and `App::start`.
+- `ev` accepts handlers which return `Msg` and `()` (#394).
+- [BREAKING] `EventHandler::new` accepts only handlers which return `Option<Msg>`.
+- [BREAKING] `ev`-like functions require `'static` bound for generic types (temporary). 
 
 ## v0.6.0
 - Implemented `UpdateEl` for `Filter` and `FilterMap`.

--- a/examples/subscribe/src/lib.rs
+++ b/examples/subscribe/src/lib.rs
@@ -55,13 +55,11 @@ enum Msg {
     Counter(counter::Msg),
     ResetCounter,
 
-    NumberReceived(i32),
     StringReceived(String),
     UrlRequested(subs::UrlRequested),
     UrlChanged(subs::UrlChanged),
 
     SetTimeout,
-    OnTimeout,
     CancelTimeout,
 
     OnResize,
@@ -72,7 +70,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         Msg::Subscribe => {
             log!("--- Subscribe ---");
             model.sub_handles = vec![
-                orders.subscribe_with_handle(Msg::NumberReceived),
+                orders.subscribe_with_handle(|number: i32| log!("Number Received", number)),
                 orders.subscribe_with_handle(Msg::StringReceived),
                 orders.subscribe_with_handle(Msg::StringReceived),
             ];
@@ -99,9 +97,6 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         Msg::ResetCounter => {
             orders.notify(counter::DoReset);
         }
-        Msg::NumberReceived(message) => {
-            log!("Number Received", message);
-        }
         Msg::StringReceived(message) => {
             log!("String Received", message);
         }
@@ -114,10 +109,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         Msg::SetTimeout => {
             log!("--- Set timeout ---");
             model.timeout_handle =
-                Some(orders.perform_cmd_with_handle(cmds::timeout(2000, || Msg::OnTimeout)));
-        }
-        Msg::OnTimeout => {
-            log!("Timeout!!");
+                Some(orders.perform_cmd_with_handle(cmds::timeout(2000, || log!("Timeout!!"))));
         }
         Msg::CancelTimeout => {
             log!("--- Cancel timeout ---");
@@ -144,7 +136,7 @@ fn view(model: &Model) -> impl View<Msg> {
         centered_column.clone(),
         "Open Console log, please",
         divider(),
-        // --- Subscribe | Notify | Unsubscribe
+        // --- Subscribe | Notify | Unsubscribe ---
         div![with_spaces(vec![
             button![ev(Ev::Click, |_| Msg::Subscribe), "1. Subscribe"],
             button![ev(Ev::Click, |_| Msg::Notify), "2. Notify"],
@@ -161,6 +153,7 @@ fn view(model: &Model) -> impl View<Msg> {
             button![
                 style! {St::MarginTop => rem(0.5)},
                 ev(Ev::Click, |_| Msg::ResetCounter),
+                ev(Ev::Click, |_| log!("Reset counter!")),
                 "Reset counter"
             ],
         ],

--- a/examples/tea_component/src/counter.rs
+++ b/examples/tea_component/src/counter.rs
@@ -53,7 +53,7 @@ pub fn update<Ms: 'static, GMs>(
 //     View
 // ------ ------
 
-pub fn view<Ms>(
+pub fn view<Ms: 'static>(
     model: &Model,
     on_click: impl FnOnce() -> Ms + Clone + 'static,
     to_msg: impl FnOnce(Msg) -> Ms + Clone + 'static,

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -187,7 +187,6 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             let input = model.refs.editing_todo_input.clone();
             orders.after_next_render(move |_| {
                 input.get().expect("get `editing_todo_input`").select();
-                Msg::NoOp
             });
         }
         Msg::EditingTodoTitleChanged(title) => {

--- a/examples/update_from_js/src/lib.rs
+++ b/examples/update_from_js/src/lib.rs
@@ -19,7 +19,6 @@ struct Model {
 enum Msg {
     JsReady(bool),
     Tick(String),
-    NoOp,
 }
 
 fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
@@ -35,19 +34,13 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
                 //
                 // _Note:_ Create an issue in Seed's repo if this solution is not usable for you,
                 // we can find another one or try to integrate some locks.
-                orders.perform_cmd(wrap_in_future(enableClock));
+                orders.perform_cmd(async { enableClock() });
             } else {
                 log!("JS is NOT ready!");
             }
         }
         Msg::Tick(time) => model.time_from_js = Some(time),
-        Msg::NoOp => (),
     }
-}
-
-async fn wrap_in_future(f: impl FnOnce()) -> Msg {
-    f();
-    Msg::NoOp
 }
 
 // ------ ------

--- a/src/app.rs
+++ b/src/app.rs
@@ -526,7 +526,7 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> App<Ms, Mdl, ElC, GMs> {
                 .after_next_render_callbacks
                 .replace(Vec::new())
                 .into_iter()
-                .map(|callback| Effect::Msg(callback(timestamp_delta)))
+                .filter_map(|callback| callback(timestamp_delta).map(Effect::Msg))
                 .collect(),
         );
     }

--- a/src/app/cmds.rs
+++ b/src/app/cmds.rs
@@ -18,7 +18,7 @@ use gloo_timers::future::TimeoutFuture;
 ///
 /// # Panics
 ///
-/// Panics when command doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+/// Panics when the command doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
 pub fn timeout<MsU>(
     ms: u32,
     handler: impl FnOnce() -> MsU + Clone + 'static,

--- a/src/app/cmds.rs
+++ b/src/app/cmds.rs
@@ -11,10 +11,15 @@ use gloo_timers::future::TimeoutFuture;
 ///
 /// ```rust,no_run
 ///orders.perform_cmd_with_handle(cmds::timeout(2000, || Msg::OnTimeout));
+///orders.perform_cmd(cmds::timeout(1000, || log!("Tick!")));
 /// ```
-pub fn timeout<Ms>(
+///
+/// # Panics
+///
+/// Panics when command doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+pub fn timeout<MsU>(
     ms: u32,
-    handler: impl FnOnce() -> Ms + Clone + 'static,
-) -> impl Future<Output = Ms> {
+    handler: impl FnOnce() -> MsU + Clone + 'static,
+) -> impl Future<Output = MsU> {
     TimeoutFuture::new(ms).map(move |_| handler())
 }

--- a/src/app/cmds.rs
+++ b/src/app/cmds.rs
@@ -7,6 +7,8 @@ use gloo_timers::future::TimeoutFuture;
 
 /// Set timeout in milliseconds.
 ///
+/// Handler has to return `Msg` or `()`.
+///
 /// # Example
 ///
 /// ```rust,no_run

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -20,6 +20,6 @@ pub struct AppData<Ms: 'static, Mdl> {
     pub msg_listeners: RefCell<MsgListeners<Ms>>,
     pub scheduled_render_handle: RefCell<Option<util::RequestAnimationFrameHandle>>,
     pub after_next_render_callbacks:
-        RefCell<Vec<Box<dyn FnOnce(Option<RenderTimestampDelta>) -> Ms>>>,
+        RefCell<Vec<Box<dyn FnOnce(Option<RenderTimestampDelta>) -> Option<Ms>>>>,
     pub render_timestamp: Cell<Option<RenderTimestamp>>,
 }

--- a/src/app/orders.rs
+++ b/src/app/orders.rs
@@ -192,7 +192,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
         handler: impl FnOnce(SubMs) -> MsU + Clone + 'static,
     ) -> SubHandle;
 
-    /// Stream `Msg`s.
+    /// Stream `Msg`s or `()`s.
     ///
     /// # Example
     ///
@@ -202,9 +202,16 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     /// ```
     ///
     /// _Note:_: Use the alternative `stream_with_handle` to control `stream`'s lifetime.
-    fn stream(&mut self, stream: impl Stream<Item = Ms> + 'static) -> &mut Self;
+    ///
+    /// # Panics
+    ///
+    /// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    #[allow(clippy::shadow_unrelated)]
+    // @TODO remove `'static`s once `optin_builtin_traits`
+    // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
+    fn stream<MsU: 'static>(&mut self, stream: impl Stream<Item = MsU> + 'static) -> &mut Self;
 
-    /// Stream `Msg`s.
+    /// Stream `Msg`s or `()`s.
     /// - Returns `StreamHandle` that you should save to your `Model`.
     ///   The `stream` is cancelled on the handle drop.
     ///
@@ -214,6 +221,16 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///let timer_handler = orders.stream_with_handle(streams::interval(1000, || Msg::OnTick)));
     ///let stream_handler = orders.stream_with_handle(streams::window_event(Ev::Resize, |_| Msg::OnResize));
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
     #[must_use = "stream is stopped on its handle drop"]
-    fn stream_with_handle(&mut self, stream: impl Stream<Item = Ms> + 'static) -> StreamHandle;
+    #[allow(clippy::shadow_unrelated)]
+    // @TODO remove `'static`s once `optin_builtin_traits`
+    // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
+    fn stream_with_handle<MsU: 'static>(
+        &mut self,
+        stream: impl Stream<Item = MsU> + 'static,
+    ) -> StreamHandle;
 }

--- a/src/app/orders.rs
+++ b/src/app/orders.rs
@@ -137,11 +137,13 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
 
     /// Subscribe for messages with the `handler`s input type.
     ///
+    /// Handler has to return `Msg` or `()`.
+    ///
     /// # Example
     ///
     /// ```rust,no_run
     ///orders.subscribe(Msg::Reset);  // `Msg::Reset(counter::DoReset)`
-    ///orders.subscribe(|greeting: &'static str| { log!(greeting); Msg::NoOp });
+    ///orders.subscribe(|greeting: &'static str| { log!(greeting) });
     ///orders.subscribe(Msg::UrlChanged)  // `update(... Msg::UrlChanged(subs::UrlChanged(url)) =>`
     /// ...
     ///orders.notify(counter::DoReset);
@@ -149,29 +151,45 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     /// ```
     ///
     /// _Note:_: Use the alternative `subscribe_with_handle` to control `sub`'s lifetime.
-    fn subscribe<SubMs: 'static + Clone>(
+    ///
+    /// # Panics
+    ///
+    /// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    #[allow(clippy::shadow_unrelated)]
+    // @TODO remove `'static`s once `optin_builtin_traits`
+    // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
+    fn subscribe<MsU: 'static, SubMs: 'static + Clone>(
         &mut self,
-        handler: impl FnOnce(SubMs) -> Ms + Clone + 'static,
+        handler: impl FnOnce(SubMs) -> MsU + Clone + 'static,
     ) -> &mut Self;
 
     /// Subscribe for messages with the `handler`s input type.
     /// - Returns `SubHandle` that you should save to your `Model`.
     ///   The `sub` is cancelled on the handle drop.
     ///
+    /// Handler has to return `Msg` or `()`.
+    ///
     /// # Example
     ///
     /// ```rust,no_run
     ///let sub_handle = orders.subscribe_with_handle(Msg::Reset);  // `Msg::Reset(counter::DoReset)`
-    ///orders.subscribe_with_handle(|greeting: &'static str| { log!(greeting); Msg::NoOp });
+    ///orders.subscribe_with_handle(|greeting: &'static str| { log!(greeting) });
     ///let url_changed_handle = orders.subscribe_with_handle(Msg::UrlChanged)  // `update(... Msg::UrlChanged(subs::UrlChanged(url)) =>`
     /// ...
     ///orders.notify(counter::DoReset);
     ///orders.notify("Hello!");
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
     #[must_use = "subscription is cancelled on its handle drop"]
-    fn subscribe_with_handle<SubMs: 'static + Clone>(
+    #[allow(clippy::shadow_unrelated)]
+    // @TODO remove `'static`s once `optin_builtin_traits`
+    // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
+    fn subscribe_with_handle<MsU: 'static, SubMs: 'static + Clone>(
         &mut self,
-        handler: impl FnOnce(SubMs) -> Ms + Clone + 'static,
+        handler: impl FnOnce(SubMs) -> MsU + Clone + 'static,
     ) -> SubHandle;
 
     /// Stream `Msg`s.

--- a/src/app/orders.rs
+++ b/src/app/orders.rs
@@ -49,7 +49,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///orders.notify("Hello!");
     /// ...
     ///orders.subscribe(Msg::Reset);  // `Msg::Reset(counter::DoReset)`
-    ///orders.subscribe(|greeting: &'static str| { log!(greeting) });
+    ///orders.subscribe(|greeting: &'static str| log!(greeting));
     /// ```
     ///
     /// _Note:_: All notifications are pushed to the queue - i.e. `update` function is NOT called immediately.
@@ -98,7 +98,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// # Panics
     ///
-    /// Panics when command doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the command doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
     #[must_use = "cmd is aborted on its handle drop"]
     #[allow(clippy::shadow_unrelated)]
     // @TODO remove `'static`s once `optin_builtin_traits`
@@ -152,7 +152,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// # Panics
     ///
-    /// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
     #[allow(clippy::shadow_unrelated)]
     // @TODO remove `'static`s once `optin_builtin_traits`
     // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
@@ -169,7 +169,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// ```rust,no_run
     ///orders.subscribe(Msg::Reset);  // `Msg::Reset(counter::DoReset)`
-    ///orders.subscribe(|greeting: &'static str| { log!(greeting) });
+    ///orders.subscribe(|greeting: &'static str| log!(greeting));
     ///orders.subscribe(Msg::UrlChanged)  // `update(... Msg::UrlChanged(subs::UrlChanged(url)) =>`
     /// ...
     ///orders.notify(counter::DoReset);
@@ -180,7 +180,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// # Panics
     ///
-    /// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
     #[allow(clippy::shadow_unrelated)]
     // @TODO remove `'static`s once `optin_builtin_traits`
     // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
@@ -199,7 +199,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// ```rust,no_run
     ///let sub_handle = orders.subscribe_with_handle(Msg::Reset);  // `Msg::Reset(counter::DoReset)`
-    ///orders.subscribe_with_handle(|greeting: &'static str| { log!(greeting) });
+    ///orders.subscribe_with_handle(|greeting: &'static str| log!(greeting));
     ///let url_changed_handle = orders.subscribe_with_handle(Msg::UrlChanged)  // `update(... Msg::UrlChanged(subs::UrlChanged(url)) =>`
     /// ...
     ///orders.notify(counter::DoReset);
@@ -208,7 +208,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// # Panics
     ///
-    /// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
     #[must_use = "subscription is cancelled on its handle drop"]
     #[allow(clippy::shadow_unrelated)]
     // @TODO remove `'static`s once `optin_builtin_traits`
@@ -231,7 +231,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// # Panics
     ///
-    /// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
     #[allow(clippy::shadow_unrelated)]
     // @TODO remove `'static`s once `optin_builtin_traits`
     // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
@@ -250,7 +250,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// # Panics
     ///
-    /// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
     #[must_use = "stream is stopped on its handle drop"]
     #[allow(clippy::shadow_unrelated)]
     // @TODO remove `'static`s once `optin_builtin_traits`

--- a/src/app/orders.rs
+++ b/src/app/orders.rs
@@ -145,12 +145,20 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// - It's useful when you want to use DOM API or make animations.
     /// - You can call this function multiple times - callbacks will be executed in the same order.
+    /// - Callback has to return `Msg` or `()`.
     ///
     /// _Note:_ [performance.now()](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now)
     ///  is used under the hood to get timestamps.
-    fn after_next_render(
+    ///
+    /// # Panics
+    ///
+    /// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    #[allow(clippy::shadow_unrelated)]
+    // @TODO remove `'static`s once `optin_builtin_traits`
+    // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
+    fn after_next_render<MsU: 'static>(
         &mut self,
-        callback: impl FnOnce(Option<RenderTimestampDelta>) -> Ms + 'static,
+        callback: impl FnOnce(Option<RenderTimestampDelta>) -> MsU + 'static,
     ) -> &mut Self;
 
     /// Subscribe for messages with the `handler`s input type.

--- a/src/app/streams.rs
+++ b/src/app/streams.rs
@@ -5,15 +5,22 @@ use gloo_timers::future::IntervalStream;
 
 /// Stream no values on predefined time interval in milliseconds.
 ///
+/// Handler has to return `Msg` or `()`.
+///
 /// # Example
 ///
 /// ```rust,no_run
-///orders.stream_with_handle(streams::interval(1000, || Msg::OnTick));
+///orders.stream(streams::interval(1000, || Msg::OnTick));
+///orders.stream_with_handle(streams::interval(1000, || log!("Tick!")));
 /// ```
-pub fn interval<Ms>(
+///
+/// # Panics
+///
+/// Panics when stream doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+pub fn interval<MsU>(
     ms: u32,
-    handler: impl FnOnce() -> Ms + Clone + 'static,
-) -> impl Stream<Item = Ms> {
+    handler: impl FnOnce() -> MsU + Clone + 'static,
+) -> impl Stream<Item = MsU> {
     IntervalStream::new(ms).map(move |_| handler.clone()())
 }
 

--- a/src/app/streams.rs
+++ b/src/app/streams.rs
@@ -16,7 +16,7 @@ use gloo_timers::future::IntervalStream;
 ///
 /// # Panics
 ///
-/// Panics when stream doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+/// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
 pub fn interval<MsU>(
     ms: u32,
     handler: impl FnOnce() -> MsU + Clone + 'static,

--- a/src/app/streams/window_event.rs
+++ b/src/app/streams/window_event.rs
@@ -23,7 +23,7 @@ use web_sys::{Event, EventTarget};
 ///
 /// # Panics
 ///
-/// Panics when stream doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+/// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
 pub fn window_event<MsU>(
     trigger: impl Into<Ev>,
     handler: impl FnOnce(Event) -> MsU + Clone + 'static,

--- a/src/app/streams/window_event.rs
+++ b/src/app/streams/window_event.rs
@@ -12,15 +12,22 @@ use web_sys::{Event, EventTarget};
 
 /// Stream `Window` `web_sys::Event`s.
 ///
+/// Handler has to return `Msg` or `()`.
+///
 /// # Example
 ///
 /// ```rust,no_run
 ///orders.stream(streams::window_event(Ev::Resize, |_| Msg::OnResize));
+///orders.stream_with_handle(streams::window_event(Ev::Click, |_| log!("Clicked!")));
 /// ```
-pub fn window_event<Ms>(
+///
+/// # Panics
+///
+/// Panics when stream doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+pub fn window_event<MsU>(
     trigger: impl Into<Ev>,
-    handler: impl FnOnce(Event) -> Ms + Clone + 'static,
-) -> impl Stream<Item = Ms> {
+    handler: impl FnOnce(Event) -> MsU + Clone + 'static,
+) -> impl Stream<Item = MsU> {
     EventStream::new(&window(), trigger.into()).map(move |event| handler.clone()(event))
 }
 

--- a/src/browser/dom/event_handler.rs
+++ b/src/browser/dom/event_handler.rs
@@ -124,6 +124,12 @@ pub fn raw_ev<Ms: 'static, MsU: 'static>(
 
 /// Create an event handler that accepts a closure, and passes a `web_sys::Event`, allowing full control of
 /// event-handling.
+///
+/// Handler has to return `Msg` or `()`.
+///
+/// # Panics
+///
+/// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
 #[allow(clippy::shadow_unrelated)]
 // @TODO remove `'static`s once `optin_builtin_traits`
 // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable

--- a/src/browser/dom/event_handler.rs
+++ b/src/browser/dom/event_handler.rs
@@ -129,7 +129,7 @@ pub fn raw_ev<Ms: 'static, MsU: 'static>(
 ///
 /// # Panics
 ///
-/// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+/// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
 #[allow(clippy::shadow_unrelated)]
 // @TODO remove `'static`s once `optin_builtin_traits`
 // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable

--- a/src/browser/dom/event_handler.rs
+++ b/src/browser/dom/event_handler.rs
@@ -3,13 +3,27 @@
 
 use super::super::util;
 use crate::virtual_dom::{Ev, EventHandler};
+use std::any::{Any, TypeId};
 use wasm_bindgen::JsCast;
 
 /// Create an event that passes a String of field text, for fast input handling.
-pub fn input_ev<Ms>(
+#[allow(clippy::shadow_unrelated)]
+// @TODO remove `'static`s once `optin_builtin_traits`
+// @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
+pub fn input_ev<Ms: 'static, MsU: 'static>(
     trigger: impl Into<Ev>,
-    handler: impl FnOnce(String) -> Ms + 'static + Clone,
+    handler: impl FnOnce(String) -> MsU + 'static + Clone,
 ) -> EventHandler<Ms> {
+    // @TODO refactor once `optin_builtin_traits` is stable (https://github.com/seed-rs/seed/issues/391)
+    let t_type = TypeId::of::<MsU>();
+    if t_type != TypeId::of::<Ms>() && t_type != TypeId::of::<()>() {
+        panic!("Handler can return only Msg or ()!");
+    }
+    let handler = move |text| {
+        let output = &mut Some(handler.clone()(text)) as &mut dyn Any;
+        output.downcast_mut::<Option<Ms>>().and_then(Option::take)
+    };
+
     let closure_handler = move |event: web_sys::Event| {
         let value = event
             .target()
@@ -18,42 +32,80 @@ pub fn input_ev<Ms>(
             .and_then(util::get_value)
             .map_err(crate::error)
             .unwrap_or_default();
-
-        (handler.clone())(value)
+        handler(value)
     };
     EventHandler::new(trigger, closure_handler)
 }
 
 /// Create an event that passes a `web_sys::KeyboardEvent`, allowing easy access
 /// to items like `key_code`() and key().
-pub fn keyboard_ev<Ms>(
+#[allow(clippy::shadow_unrelated)]
+// @TODO remove `'static`s once `optin_builtin_traits`
+// @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
+pub fn keyboard_ev<Ms: 'static, MsU: 'static>(
     trigger: impl Into<Ev>,
-    handler: impl FnOnce(web_sys::KeyboardEvent) -> Ms + 'static + Clone,
+    handler: impl FnOnce(web_sys::KeyboardEvent) -> MsU + 'static + Clone,
 ) -> EventHandler<Ms> {
+    // @TODO refactor once `optin_builtin_traits` is stable (https://github.com/seed-rs/seed/issues/391)
+    let t_type = TypeId::of::<MsU>();
+    if t_type != TypeId::of::<Ms>() && t_type != TypeId::of::<()>() {
+        panic!("Handler can return only Msg or ()!");
+    }
+    let handler = move |event| {
+        let output = &mut Some(handler.clone()(event)) as &mut dyn Any;
+        output.downcast_mut::<Option<Ms>>().and_then(Option::take)
+    };
+
     let closure_handler = move |event: web_sys::Event| {
-        (handler.clone())(event.dyn_ref::<web_sys::KeyboardEvent>().unwrap().clone())
+        handler(event.dyn_ref::<web_sys::KeyboardEvent>().unwrap().clone())
     };
     EventHandler::new(trigger, closure_handler)
 }
 
 /// See `keyboard_ev`
-pub fn mouse_ev<Ms>(
+#[allow(clippy::shadow_unrelated)]
+// @TODO remove `'static`s once `optin_builtin_traits`
+// @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
+pub fn mouse_ev<Ms: 'static, MsU: 'static>(
     trigger: impl Into<Ev>,
-    handler: impl FnOnce(web_sys::MouseEvent) -> Ms + 'static + Clone,
+    handler: impl FnOnce(web_sys::MouseEvent) -> MsU + 'static + Clone,
 ) -> EventHandler<Ms> {
+    // @TODO refactor once `optin_builtin_traits` is stable (https://github.com/seed-rs/seed/issues/391)
+    let t_type = TypeId::of::<MsU>();
+    if t_type != TypeId::of::<Ms>() && t_type != TypeId::of::<()>() {
+        panic!("Handler can return only Msg or ()!");
+    }
+    let handler = move |event| {
+        let output = &mut Some(handler.clone()(event)) as &mut dyn Any;
+        output.downcast_mut::<Option<Ms>>().and_then(Option::take)
+    };
+
     let closure_handler = move |event: web_sys::Event| {
-        (handler.clone())(event.dyn_ref::<web_sys::MouseEvent>().unwrap().clone())
+        handler(event.dyn_ref::<web_sys::MouseEvent>().unwrap().clone())
     };
     EventHandler::new(trigger, closure_handler)
 }
 
 /// See `keyboard_ev`
-pub fn pointer_ev<Ms>(
+#[allow(clippy::shadow_unrelated)]
+// @TODO remove `'static`s once `optin_builtin_traits`
+// @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
+pub fn pointer_ev<Ms: 'static, MsU: 'static>(
     trigger: impl Into<Ev>,
-    handler: impl FnOnce(web_sys::PointerEvent) -> Ms + 'static + Clone,
+    handler: impl FnOnce(web_sys::PointerEvent) -> MsU + 'static + Clone,
 ) -> EventHandler<Ms> {
+    // @TODO refactor once `optin_builtin_traits` is stable (https://github.com/seed-rs/seed/issues/391)
+    let t_type = TypeId::of::<MsU>();
+    if t_type != TypeId::of::<Ms>() && t_type != TypeId::of::<()>() {
+        panic!("Handler can return only Msg or ()!");
+    }
+    let handler = move |event| {
+        let output = &mut Some(handler.clone()(event)) as &mut dyn Any;
+        output.downcast_mut::<Option<Ms>>().and_then(Option::take)
+    };
+
     let closure_handler = move |event: web_sys::Event| {
-        (handler.clone())(event.dyn_ref::<web_sys::PointerEvent>().unwrap().clone())
+        handler(event.dyn_ref::<web_sys::PointerEvent>().unwrap().clone())
     };
     EventHandler::new(trigger, closure_handler)
 }
@@ -61,27 +113,42 @@ pub fn pointer_ev<Ms>(
 /// Create an event that accepts a closure, and passes a `web_sys::Event`, allowing full control of
 /// event-handling.
 #[deprecated(since = "0.6.0", note = "Use `ev` instead.")]
-pub fn raw_ev<Ms>(
+// @TODO remove `'static`s once `optin_builtin_traits`
+// @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
+pub fn raw_ev<Ms: 'static, MsU: 'static>(
     trigger: impl Into<Ev>,
-    handler: impl FnOnce(web_sys::Event) -> Ms + 'static + Clone,
+    handler: impl FnOnce(web_sys::Event) -> MsU + 'static + Clone,
 ) -> EventHandler<Ms> {
     ev(trigger, handler)
 }
 
 /// Create an event handler that accepts a closure, and passes a `web_sys::Event`, allowing full control of
 /// event-handling.
-pub fn ev<Ms>(
+#[allow(clippy::shadow_unrelated)]
+// @TODO remove `'static`s once `optin_builtin_traits`
+// @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
+pub fn ev<Ms: 'static, MsU: 'static>(
     trigger: impl Into<Ev>,
-    handler: impl FnOnce(web_sys::Event) -> Ms + 'static + Clone,
+    handler: impl FnOnce(web_sys::Event) -> MsU + 'static + Clone,
 ) -> EventHandler<Ms> {
-    let closure_handler = move |event: web_sys::Event| (handler.clone())(event);
+    // @TODO refactor once `optin_builtin_traits` is stable (https://github.com/seed-rs/seed/issues/391)
+    let t_type = TypeId::of::<MsU>();
+    if t_type != TypeId::of::<Ms>() && t_type != TypeId::of::<()>() {
+        panic!("Handler can return only Msg or ()!");
+    }
+    let handler = move |event| {
+        let output = &mut Some(handler.clone()(event)) as &mut dyn Any;
+        output.downcast_mut::<Option<Ms>>().and_then(Option::take)
+    };
+
+    let closure_handler = move |event: web_sys::Event| handler(event);
     EventHandler::new(trigger, closure_handler)
 }
 
 /// Create an event that passes no data, other than it occurred. Foregoes using a closure,
 /// in favor of pointing to a message directly.
 pub fn simple_ev<Ms: Clone + 'static>(trigger: impl Into<Ev>, message: Ms) -> EventHandler<Ms> {
-    let handler = || message;
+    let handler = || Some(message);
     let closure_handler = move |_| handler.clone()();
     EventHandler::new(trigger, closure_handler)
 }

--- a/src/virtual_dom/el_ref.rs
+++ b/src/virtual_dom/el_ref.rs
@@ -103,7 +103,6 @@ impl<E: Clone + JsCast> ElRef<E> {
     ///         .expect("get `my_input`")
     ///         .focus()
     ///         .expect("focus 'my_input'");
-    ///     Msg::NoOp
     ///  });
     ///
     pub fn map_type<T>(&self) -> ElRef<T> {

--- a/src/virtual_dom/event_handler_manager/listener.rs
+++ b/src/virtual_dom/event_handler_manager/listener.rs
@@ -45,8 +45,9 @@ impl<Ms> Listener<Ms> {
                     event_handlers
                 });
                 for handler_callback in handler_callbacks {
-                    let msg = handler_callback(event.clone());
-                    mailbox.send(msg);
+                    if let Some(msg) = handler_callback(event.clone()) {
+                        mailbox.send(msg);
+                    }
                 }
             }),
         );


### PR DESCRIPTION
Resolves #391 

`ev`, `orders.subscribe`, `orders.after_next_render`, etc. accept handlers which return `Msg` or `()`.

+ CI fix