### PR TITLE
IntoNodes instead of View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,18 +24,18 @@
 - [BREAKING] Removed module `next_tick`.
 - Added method `App::start` (alternative to `AppBuilder`) (#376, #382).
 - Added trait `GetElement` + included in the `prelude` (alternative to `MountPoint`, used in `AppStart`).
-- Updated example `subscribe` to use `App::start`.
 - Derive `Debug` for `ElRef`.
 - Added macros `C!` and `IF!` and helper `not` (#375).
 - Added trait `ToClasses` + included in the `prelude`.
 - Updated `todomvc` example to use `C!`, `IF!`, `matches!` and `App::start`.
-- `ev` accepts handlers which return `Msg` and `()` (#394).
-- [BREAKING] `EventHandler::new` accepts only handlers which return `Option<Msg>`.
+- `ev` accepts handlers that return `Msg` and `()` (#394).
+- [BREAKING] `EventHandler::new` accepts only handlers that return `Option<Msg>`.
 - [BREAKING] `ev`-like functions and some `Orders` method require `'static` bound for generic types (temporary). 
-- `Orders::after_next_render` now accepts callbacks which return `Msg` or `()`.
+- `Orders::after_next_render` now accepts callbacks that return `Msg` or `()`.
 - Updated examples `update_from_js` and `todomvc`.
 - [deprecated] `View` is deprecated in favor of `IntoNodes`.
 - [BREAKING] `View` isn't implemented for `El` and `Vec<El>`.
+- [BREAKING] `Node::add_listener` renamed to `add_event_handler`.
 
 ## v0.6.0
 - Implemented `UpdateEl` for `Filter` and `FilterMap`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 - [BREAKING] `ev`-like functions and some `Orders` method require `'static` bound for generic types (temporary). 
 - `Orders::after_next_render` now accepts callbacks which return `Msg` or `()`.
 - Updated examples `update_from_js` and `todomvc`.
+- [deprecated] `View` is deprecated in favor of `IntoNodes`.
+- [BREAKING] `View` isn't implemented for `El` and `Vec<El>`.
 
 ## v0.6.0
 - Implemented `UpdateEl` for `Filter` and `FilterMap`.
@@ -45,7 +47,7 @@
 - Fixed `value` and `checked` setting for input elements (a bug in VirtualDOM patch algorithm).
 - [BREAKING] Removed unpredictable internal input listeners - Seed will not longer react to external input value changes.
 - [BREAKING] Use `EventHandler` instead of `Listener`. (`Listener` is now used as the internal DOM EventListener representation.)
-- [deprecated] - `raw_ev` is deprecated in favor of `ev`. Functionality is the same.
+- [deprecated] `raw_ev` is deprecated in favor of `ev`. Functionality is the same.
 - Improved performance - rewritten event-handling and other refactors in VirtualDOM.
 - Fixed processing of multiple event-handlers (#138).
 - Added DOM Element references - see `ElRef` and examples (`canvas`, `user_media` or `todomvc`) (#115).

--- a/examples/app_builder/src/lib.rs
+++ b/examples/app_builder/src/lib.rs
@@ -91,7 +91,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
 //     View
 // ------ ------
 
-fn view(model: &Model) -> impl View<Msg> {
+fn view(model: &Model) -> impl IntoNodes<Msg> {
     vec![
         button![
             format!("Clicked: {}", model.clicks),

--- a/examples/canvas/src/lib.rs
+++ b/examples/canvas/src/lib.rs
@@ -90,7 +90,7 @@ fn draw(canvas: &ElRef<HtmlCanvasElement>, fill_color: Color) {
 //     View
 // ------ ------
 
-fn view(model: &Model) -> impl View<Msg> {
+fn view(model: &Model) -> impl IntoNodes<Msg> {
     div![
         style! {St::Display => "flex"},
         canvas![

--- a/examples/counter_advanced/src/lib.rs
+++ b/examples/counter_advanced/src/lib.rs
@@ -46,8 +46,8 @@ fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
 
 /// The top-level view we pass to the virtual dom.
 ///  - Must accept the model as its only argument.
-///  - Output has to implement trait `ElContainer` (e.g. `Node<Msg>` or `Vec<Node<Msg>`).
-fn view(model: &Model) -> impl View<Msg> {
+///  - Output has to implement trait `IntoNodes` (e.g. `Node<Msg>` or `Vec<Node<Msg>`).
+fn view(model: &Model) -> impl IntoNodes<Msg> {
     let plural = if model.count.abs() == 1 { "" } else { "s" };
     let text = format!("{} {}{} so far", model.count, model.what_we_count, plural);
 

--- a/examples/drop_zone/src/lib.rs
+++ b/examples/drop_zone/src/lib.rs
@@ -74,7 +74,7 @@ macro_rules! stop_and_prevent {
      };
 }
 
-fn view(model: &Model) -> impl View<Msg> {
+fn view(model: &Model) -> impl IntoNodes<Msg> {
     div![
         style![
             St::Height => px(200),

--- a/examples/mathjax/src/lib.rs
+++ b/examples/mathjax/src/lib.rs
@@ -74,7 +74,7 @@ fn _dirac_3(left: &str, middle: &str, right: &str) -> String {
 }
 
 #[allow(clippy::too_many_lines)]
-fn view(model: &Model) -> impl View<Msg> {
+fn view(model: &Model) -> impl IntoNodes<Msg> {
     div![
         style!{
             St::MaxWidth => px(750),

--- a/examples/orders/src/lib.rs
+++ b/examples/orders/src/lib.rs
@@ -59,7 +59,7 @@ async fn write_emoticon_after_delay(emoticon: String) -> Msg {
 //     View
 // ------ ------
 
-fn view(model: &Model) -> impl View<Msg> {
+fn view(model: &Model) -> impl IntoNodes<Msg> {
     div![
         style![
             St::Display => "flex",

--- a/examples/server_integration/client/src/lib.rs
+++ b/examples/server_integration/client/src/lib.rs
@@ -57,7 +57,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
 //     View
 // ------ ------
 
-fn view(model: &Model) -> impl View<Msg> {
+fn view(model: &Model) -> impl IntoNodes<Msg> {
     div![
         style! {
             St::FontFamily => "sans-serif";

--- a/examples/subscribe/src/lib.rs
+++ b/examples/subscribe/src/lib.rs
@@ -125,7 +125,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
 //     View
 // ------ ------
 
-fn view(model: &Model) -> impl View<Msg> {
+fn view(model: &Model) -> impl IntoNodes<Msg> {
     let centered_column = style! {
         St::Display => "flex",
         St::FlexDirection => "column",

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -215,7 +215,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
 //     View
 // ------ ------
 
-fn view(model: &Model) -> impl View<Msg> {
+fn view(model: &Model) -> impl IntoNodes<Msg> {
     let data = &model.data;
     nodes![
         view_header(&data.new_todo_title),

--- a/examples/user_media/src/lib.rs
+++ b/examples/user_media/src/lib.rs
@@ -65,7 +65,7 @@ fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
 //     View
 // ------ ------
 
-fn view(model: &Model) -> impl View<Msg> {
+fn view(model: &Model) -> impl IntoNodes<Msg> {
     video![
         el_ref(&model.video),
         attrs! {

--- a/examples/websocket/src/client.rs
+++ b/examples/websocket/src/client.rs
@@ -119,7 +119,7 @@ fn update(msg: Msg, mut model: &mut Model, orders: &mut impl Orders<Msg>) {
 //     View
 // ------ ------
 
-fn view(model: &Model) -> impl View<Msg> {
+fn view(model: &Model) -> impl IntoNodes<Msg> {
     let data = &model.data;
 
     vec![

--- a/src/app/builder.rs
+++ b/src/app/builder.rs
@@ -1,6 +1,6 @@
 use super::{types::*, App, AppInitCfg, OrdersContainer};
 use crate::browser::{url, Url};
-use crate::virtual_dom::View;
+use crate::virtual_dom::IntoNodes;
 use std::marker::PhantomData;
 
 pub mod after_mount;
@@ -35,9 +35,9 @@ impl Default for BeforeAfterInitAPI<UndefinedAfterMount> {
 }
 
 // TODO Remove when removing the other `InitAPI`s.
-pub trait InitAPI<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
+pub trait InitAPI<Ms: 'static, Mdl, INodes: IntoNodes<Ms>, GMs> {
     type Builder;
-    fn build(builder: Self::Builder) -> App<Ms, Mdl, ElC, GMs>;
+    fn build(builder: Self::Builder) -> App<Ms, Mdl, INodes, GMs>;
 }
 
 // TODO Remove when removing the other `InitAPI`s.
@@ -61,9 +61,9 @@ pub trait InitAPIData {
     fn after_mount<
         Ms: 'static,
         Mdl,
-        ElC: View<Ms>,
+        INodes: IntoNodes<Ms>,
         GMs,
-        NewIAM: IntoAfterMount<Ms, Mdl, ElC, GMs>,
+        NewIAM: IntoAfterMount<Ms, Mdl, INodes, GMs>,
     >(
         self,
         into_after_mount: NewIAM,
@@ -73,7 +73,7 @@ pub trait InitAPIData {
         since = "0.5.0",
         note = "Used for compatibility with old Init API. Use `before_mount` and `after_mount` instead."
     )]
-    fn init<Ms: 'static, Mdl, ElC: View<Ms>, GMs, NewII: IntoInit<Ms, Mdl, ElC, GMs>>(
+    fn init<Ms: 'static, Mdl, INodes: IntoNodes<Ms>, GMs, NewII: IntoInit<Ms, Mdl, INodes, GMs>>(
         self,
         into_init: NewII,
     ) -> MountPointInitInitAPI<Self::MountPoint, NewII>;
@@ -95,14 +95,14 @@ pub trait InitAPIData {
 impl<
         Ms: 'static,
         Mdl: 'static,
-        ElC: 'static + View<Ms>,
+        INodes: 'static + IntoNodes<Ms>,
         GMs: 'static,
         MP: MountPoint,
-        II: IntoInit<Ms, Mdl, ElC, GMs>,
-    > InitAPI<Ms, Mdl, ElC, GMs> for MountPointInitInitAPI<MP, II>
+        II: IntoInit<Ms, Mdl, INodes, GMs>,
+    > InitAPI<Ms, Mdl, INodes, GMs> for MountPointInitInitAPI<MP, II>
 {
-    type Builder = Builder<Ms, Mdl, ElC, GMs, Self>;
-    fn build(builder: Self::Builder) -> App<Ms, Mdl, ElC, GMs> {
+    type Builder = Builder<Ms, Mdl, INodes, GMs, Self>;
+    fn build(builder: Self::Builder) -> App<Ms, Mdl, INodes, GMs> {
         let MountPointInitInitAPI {
             into_init,
             mount_point,
@@ -134,13 +134,13 @@ impl<
 impl<
         Ms: 'static,
         Mdl: 'static,
-        ElC: 'static + View<Ms>,
+        INodes: 'static + IntoNodes<Ms>,
         GMs: 'static,
-        IAM: 'static + IntoAfterMount<Ms, Mdl, ElC, GMs>,
-    > InitAPI<Ms, Mdl, ElC, GMs> for BeforeAfterInitAPI<IAM>
+        IAM: 'static + IntoAfterMount<Ms, Mdl, INodes, GMs>,
+    > InitAPI<Ms, Mdl, INodes, GMs> for BeforeAfterInitAPI<IAM>
 {
-    type Builder = Builder<Ms, Mdl, ElC, GMs, Self>;
-    fn build(builder: Self::Builder) -> App<Ms, Mdl, ElC, GMs> {
+    type Builder = Builder<Ms, Mdl, INodes, GMs, Self>;
+    fn build(builder: Self::Builder) -> App<Ms, Mdl, INodes, GMs> {
         let BeforeAfterInitAPI {
             before_mount_handler,
             into_after_mount,
@@ -167,11 +167,11 @@ impl<
     }
 }
 // TODO Remove when removing the other `InitAPI`s.
-impl<Ms: 'static, Mdl: 'static + Default, ElC: 'static + View<Ms>, GMs: 'static>
-    InitAPI<Ms, Mdl, ElC, GMs> for UndefinedInitAPI
+impl<Ms: 'static, Mdl: 'static + Default, INodes: 'static + IntoNodes<Ms>, GMs: 'static>
+    InitAPI<Ms, Mdl, INodes, GMs> for UndefinedInitAPI
 {
-    type Builder = Builder<Ms, Mdl, ElC, GMs, Self>;
-    fn build(builder: Self::Builder) -> App<Ms, Mdl, ElC, GMs> {
+    type Builder = Builder<Ms, Mdl, INodes, GMs, Self>;
+    fn build(builder: Self::Builder) -> App<Ms, Mdl, INodes, GMs> {
         BeforeAfterInitAPI::build(Builder {
             update: builder.update,
             view: builder.view,
@@ -206,9 +206,9 @@ impl<MP, II> InitAPIData for MountPointInitInitAPI<MP, II> {
     fn after_mount<
         Ms: 'static,
         Mdl,
-        ElC: View<Ms>,
+        INodes: IntoNodes<Ms>,
         GMs,
-        NewIAM: IntoAfterMount<Ms, Mdl, ElC, GMs>,
+        NewIAM: IntoAfterMount<Ms, Mdl, INodes, GMs>,
     >(
         self,
         into_after_mount: NewIAM,
@@ -219,7 +219,7 @@ impl<MP, II> InitAPIData for MountPointInitInitAPI<MP, II> {
         }
     }
 
-    fn init<Ms: 'static, Mdl, ElC: View<Ms>, GMs, NewII: IntoInit<Ms, Mdl, ElC, GMs>>(
+    fn init<Ms: 'static, Mdl, INodes: IntoNodes<Ms>, GMs, NewII: IntoInit<Ms, Mdl, INodes, GMs>>(
         self,
         into_init: NewII,
     ) -> MountPointInitInitAPI<Self::MountPoint, NewII> {
@@ -256,9 +256,9 @@ impl<IAM> InitAPIData for BeforeAfterInitAPI<IAM> {
     fn after_mount<
         Ms: 'static,
         Mdl,
-        ElC: View<Ms>,
+        INodes: IntoNodes<Ms>,
         GMs,
-        NewIAM: IntoAfterMount<Ms, Mdl, ElC, GMs>,
+        NewIAM: IntoAfterMount<Ms, Mdl, INodes, GMs>,
     >(
         self,
         into_after_mount: NewIAM,
@@ -269,7 +269,7 @@ impl<IAM> InitAPIData for BeforeAfterInitAPI<IAM> {
         }
     }
 
-    fn init<Ms: 'static, Mdl, ElC: View<Ms>, GMs, NewII: IntoInit<Ms, Mdl, ElC, GMs>>(
+    fn init<Ms: 'static, Mdl, INodes: IntoNodes<Ms>, GMs, NewII: IntoInit<Ms, Mdl, INodes, GMs>>(
         self,
         into_init: NewII,
     ) -> MountPointInitInitAPI<Self::MountPoint, NewII> {
@@ -306,9 +306,9 @@ impl InitAPIData for UndefinedInitAPI {
     fn after_mount<
         Ms: 'static,
         Mdl,
-        ElC: View<Ms>,
+        INodes: IntoNodes<Ms>,
         GMs,
-        NewIAM: IntoAfterMount<Ms, Mdl, ElC, GMs>,
+        NewIAM: IntoAfterMount<Ms, Mdl, INodes, GMs>,
     >(
         self,
         into_after_mount: NewIAM,
@@ -319,7 +319,7 @@ impl InitAPIData for UndefinedInitAPI {
         }
     }
 
-    fn init<Ms: 'static, Mdl, ElC: View<Ms>, GMs, NewII: IntoInit<Ms, Mdl, ElC, GMs>>(
+    fn init<Ms: 'static, Mdl, INodes: IntoNodes<Ms>, GMs, NewII: IntoInit<Ms, Mdl, INodes, GMs>>(
         self,
         into_init: NewII,
     ) -> MountPointInitInitAPI<Self::MountPoint, NewII> {
@@ -340,21 +340,23 @@ impl InitAPIData for UndefinedInitAPI {
 }
 
 /// Used to create and store initial app configuration, ie items passed by the app creator.
-pub struct Builder<Ms: 'static, Mdl: 'static, ElC: View<Ms>, GMs, InitAPIType> {
-    update: UpdateFn<Ms, Mdl, ElC, GMs>,
-    view: ViewFn<Mdl, ElC>,
+pub struct Builder<Ms: 'static, Mdl: 'static, INodes: IntoNodes<Ms>, GMs, InitAPIType> {
+    update: UpdateFn<Ms, Mdl, INodes, GMs>,
+    view: ViewFn<Mdl, INodes>,
 
     routes: Option<RoutesFn<Ms>>,
     window_events: Option<WindowEventsFn<Ms, Mdl>>,
-    sink: Option<SinkFn<Ms, Mdl, ElC, GMs>>,
+    sink: Option<SinkFn<Ms, Mdl, INodes, GMs>>,
 
     // TODO: Remove when removing legacy init fields.
     init_api: InitAPIType,
 }
 
-impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> Builder<Ms, Mdl, ElC, GMs, UndefinedInitAPI> {
+impl<Ms, Mdl, INodes: IntoNodes<Ms> + 'static, GMs: 'static>
+    Builder<Ms, Mdl, INodes, GMs, UndefinedInitAPI>
+{
     /// Constructs the Builder.
-    pub(super) fn new(update: UpdateFn<Ms, Mdl, ElC, GMs>, view: ViewFn<Mdl, ElC>) -> Self {
+    pub(super) fn new(update: UpdateFn<Ms, Mdl, INodes, GMs>, view: ViewFn<Mdl, INodes>) -> Self {
         Builder {
             update,
             view,
@@ -371,22 +373,22 @@ impl<Ms, Mdl, ElC: View<Ms> + 'static, GMs: 'static> Builder<Ms, Mdl, ElC, GMs, 
 impl<
         Ms,
         Mdl,
-        ElC: View<Ms> + 'static,
+        INodes: IntoNodes<Ms> + 'static,
         GMs: 'static,
         IAM: 'static,
         MP,
         II,
         InitAPIType: InitAPIData<IntoInit = II, MountPoint = MP, IntoAfterMount = IAM>,
-    > Builder<Ms, Mdl, ElC, GMs, InitAPIType>
+    > Builder<Ms, Mdl, INodes, GMs, InitAPIType>
 {
     #[deprecated(
         since = "0.5.0",
         note = "Used for compatibility with old Init API. Use `before_mount` and `after_mount` instead."
     )]
-    pub fn init<NewII: IntoInit<Ms, Mdl, ElC, GMs>>(
+    pub fn init<NewII: IntoInit<Ms, Mdl, INodes, GMs>>(
         self,
         new_init: NewII,
-    ) -> Builder<Ms, Mdl, ElC, GMs, MountPointInitInitAPI<MP, NewII>> {
+    ) -> Builder<Ms, Mdl, INodes, GMs, MountPointInitInitAPI<MP, NewII>> {
         Builder {
             update: self.update,
             view: self.view,
@@ -423,7 +425,7 @@ impl<
     pub fn mount<NewMP: MountPoint>(
         self,
         new_mount_point: NewMP,
-    ) -> Builder<Ms, Mdl, ElC, GMs, MountPointInitInitAPI<NewMP, II>> {
+    ) -> Builder<Ms, Mdl, INodes, GMs, MountPointInitInitAPI<NewMP, II>> {
         Builder {
             update: self.update,
             view: self.view,
@@ -452,7 +454,7 @@ impl<
     pub fn before_mount(
         self,
         before_mount: impl FnOnce(Url) -> BeforeMount + 'static,
-    ) -> Builder<Ms, Mdl, ElC, GMs, BeforeAfterInitAPI<IAM>> {
+    ) -> Builder<Ms, Mdl, INodes, GMs, BeforeAfterInitAPI<IAM>> {
         Builder {
             update: self.update,
             view: self.view,
@@ -477,10 +479,10 @@ impl<
     ///    AfterMount::new(model).url_handling(UrlHandling::None)
     ///}
     /// ```
-    pub fn after_mount<AM: 'static + IntoAfterMount<Ms, Mdl, ElC, GMs>>(
+    pub fn after_mount<AM: 'static + IntoAfterMount<Ms, Mdl, INodes, GMs>>(
         self,
         after_mount: AM,
-    ) -> Builder<Ms, Mdl, ElC, GMs, BeforeAfterInitAPI<AM>> {
+    ) -> Builder<Ms, Mdl, INodes, GMs, BeforeAfterInitAPI<AM>> {
         Builder {
             update: self.update,
             view: self.view,
@@ -541,7 +543,7 @@ impl<
     ///    }
     ///}
     /// ```
-    pub fn sink(mut self, sink: SinkFn<Ms, Mdl, ElC, GMs>) -> Self {
+    pub fn sink(mut self, sink: SinkFn<Ms, Mdl, INodes, GMs>) -> Self {
         self.sink = Some(sink);
         self
     }
@@ -550,13 +552,13 @@ impl<
 impl<
         Ms: 'static,
         Mdl,
-        ElC: View<Ms> + 'static,
+        INodes: IntoNodes<Ms> + 'static,
         GMs: 'static,
-        InitAPIType: InitAPI<Ms, Mdl, ElC, GMs, Builder = Self>,
-    > Builder<Ms, Mdl, ElC, GMs, InitAPIType>
+        InitAPIType: InitAPI<Ms, Mdl, INodes, GMs, Builder = Self>,
+    > Builder<Ms, Mdl, INodes, GMs, InitAPIType>
 {
     /// Build, mount and start the app.
-    pub fn build_and_start(self) -> App<Ms, Mdl, ElC, GMs> {
+    pub fn build_and_start(self) -> App<Ms, Mdl, INodes, GMs> {
         InitAPIType::build(self).run()
     }
 }
@@ -564,18 +566,18 @@ impl<
 impl<
         Ms: 'static,
         Mdl,
-        ElC: View<Ms> + 'static,
+        INodes: IntoNodes<Ms> + 'static,
         GMs: 'static,
         MP: MountPoint,
-        II: IntoInit<Ms, Mdl, ElC, GMs>,
-    > Builder<Ms, Mdl, ElC, GMs, MountPointInitInitAPI<MP, II>>
+        II: IntoInit<Ms, Mdl, INodes, GMs>,
+    > Builder<Ms, Mdl, INodes, GMs, MountPointInitInitAPI<MP, II>>
 {
     /// Turn this [`Builder`] into an [`App`] which is ready to run.
     ///
     /// [`Builder`]: struct.Builder.html
     /// [`App`]: struct.App.html
     #[deprecated(since = "0.4.2", note = "Please use `.build_and_start` instead")]
-    pub fn finish(self) -> App<Ms, Mdl, ElC, GMs> {
+    pub fn finish(self) -> App<Ms, Mdl, INodes, GMs> {
         MountPointInitInitAPI::build(self)
     }
 }

--- a/src/app/builder/after_mount.rs
+++ b/src/app/builder/after_mount.rs
@@ -1,6 +1,6 @@
 use super::super::OrdersContainer;
 use crate::browser::Url;
-use crate::virtual_dom::View;
+use crate::virtual_dom::IntoNodes;
 
 #[allow(clippy::module_name_repetitions)]
 pub struct UndefinedAfterMount;
@@ -52,34 +52,34 @@ impl<Mdl> AfterMount<Mdl> {
 // ------ IntoAfterMount ------
 
 #[allow(clippy::module_name_repetitions)]
-pub trait IntoAfterMount<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
+pub trait IntoAfterMount<Ms: 'static, Mdl, INodes: IntoNodes<Ms>, GMs> {
     fn into_after_mount(
         self: Box<Self>,
         init_url: Url,
-        orders: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
+        orders: &mut OrdersContainer<Ms, Mdl, INodes, GMs>,
     ) -> AfterMount<Mdl>;
 }
 
-impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs, F> IntoAfterMount<Ms, Mdl, ElC, GMs> for F
+impl<Ms: 'static, Mdl, INodes: IntoNodes<Ms>, GMs, F> IntoAfterMount<Ms, Mdl, INodes, GMs> for F
 where
-    F: FnOnce(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> AfterMount<Mdl>,
+    F: FnOnce(Url, &mut OrdersContainer<Ms, Mdl, INodes, GMs>) -> AfterMount<Mdl>,
 {
     fn into_after_mount(
         self: Box<Self>,
         init_url: Url,
-        orders: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
+        orders: &mut OrdersContainer<Ms, Mdl, INodes, GMs>,
     ) -> AfterMount<Mdl> {
         self(init_url, orders)
     }
 }
 
-impl<Ms: 'static, Mdl: Default, ElC: View<Ms>, GMs> IntoAfterMount<Ms, Mdl, ElC, GMs>
+impl<Ms: 'static, Mdl: Default, INodes: IntoNodes<Ms>, GMs> IntoAfterMount<Ms, Mdl, INodes, GMs>
     for UndefinedAfterMount
 {
     fn into_after_mount(
         self: Box<Self>,
         _: Url,
-        _: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
+        _: &mut OrdersContainer<Ms, Mdl, INodes, GMs>,
     ) -> AfterMount<Mdl> {
         AfterMount::default()
     }

--- a/src/app/builder/init.rs
+++ b/src/app/builder/init.rs
@@ -1,6 +1,6 @@
 use super::{super::OrdersContainer, AfterMount, IntoAfterMount, MountType, UrlHandling};
 use crate::browser::Url;
-use crate::virtual_dom::View;
+use crate::virtual_dom::IntoNodes;
 
 pub struct UndefinedInitAPI;
 #[allow(clippy::module_name_repetitions)]
@@ -66,34 +66,39 @@ impl<Mdl> Init<Mdl> {
     since = "0.5.0",
     note = "Part of old Init API. Use `AfterMount` instead."
 )]
-pub type InitFn<Ms, Mdl, ElC, GMs> =
-    Box<dyn FnOnce(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>>;
+pub type InitFn<Ms, Mdl, INodes, GMs> =
+    Box<dyn FnOnce(Url, &mut OrdersContainer<Ms, Mdl, INodes, GMs>) -> Init<Mdl>>;
 
 #[allow(clippy::module_name_repetitions)]
 #[deprecated(
     since = "0.5.0",
     note = "Part of old Init API. Use `IntoAfterMount` and `IntoBeforeMount` instead."
 )]
-pub trait IntoInit<Ms: 'static, Mdl, ElC: View<Ms>, GMs> {
-    fn into_init(self, init_url: Url, ord: &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>;
+pub trait IntoInit<Ms: 'static, Mdl, INodes: IntoNodes<Ms>, GMs> {
+    fn into_init(self, init_url: Url, ord: &mut OrdersContainer<Ms, Mdl, INodes, GMs>)
+        -> Init<Mdl>;
 }
 
-impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs, F> IntoInit<Ms, Mdl, ElC, GMs> for F
+impl<Ms: 'static, Mdl, INodes: IntoNodes<Ms>, GMs, F> IntoInit<Ms, Mdl, INodes, GMs> for F
 where
-    F: FnOnce(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl>,
+    F: FnOnce(Url, &mut OrdersContainer<Ms, Mdl, INodes, GMs>) -> Init<Mdl>,
 {
-    fn into_init(self, init_url: Url, ord: &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Init<Mdl> {
+    fn into_init(
+        self,
+        init_url: Url,
+        ord: &mut OrdersContainer<Ms, Mdl, INodes, GMs>,
+    ) -> Init<Mdl> {
         self(init_url, ord)
     }
 }
 
-impl<Ms: 'static, Mdl, ElC: View<Ms>, GMs> IntoAfterMount<Ms, Mdl, ElC, GMs>
-    for (Init<Mdl>, OrdersContainer<Ms, Mdl, ElC, GMs>)
+impl<Ms: 'static, Mdl, INodes: IntoNodes<Ms>, GMs> IntoAfterMount<Ms, Mdl, INodes, GMs>
+    for (Init<Mdl>, OrdersContainer<Ms, Mdl, INodes, GMs>)
 {
     fn into_after_mount(
         self: Box<Self>,
         _: Url,
-        ord: &mut OrdersContainer<Ms, Mdl, ElC, GMs>,
+        ord: &mut OrdersContainer<Ms, Mdl, INodes, GMs>,
     ) -> AfterMount<Mdl> {
         let (init, old_ord) = *self;
         ord.merge(old_ord);

--- a/src/app/cfg.rs
+++ b/src/app/cfg.rs
@@ -1,31 +1,31 @@
 use super::{builder::IntoAfterMount, types::*, MountType};
-use crate::virtual_dom::View;
+use crate::virtual_dom::IntoNodes;
 use std::marker::PhantomData;
 
 #[allow(clippy::module_name_repetitions)]
-pub struct AppInitCfg<Ms, Mdl, ElC, GMs, IAM: ?Sized>
+pub struct AppInitCfg<Ms, Mdl, INodes, GMs, IAM: ?Sized>
 where
     Ms: 'static,
     Mdl: 'static,
-    ElC: View<Ms>,
-    IAM: IntoAfterMount<Ms, Mdl, ElC, GMs>,
+    INodes: IntoNodes<Ms>,
+    IAM: IntoAfterMount<Ms, Mdl, INodes, GMs>,
 {
     pub mount_type: MountType,
     pub into_after_mount: Box<IAM>,
-    pub phantom: PhantomData<(Ms, Mdl, ElC, GMs)>,
+    pub phantom: PhantomData<(Ms, Mdl, INodes, GMs)>,
 }
 
 #[allow(clippy::module_name_repetitions)]
-pub struct AppCfg<Ms, Mdl, ElC, GMs>
+pub struct AppCfg<Ms, Mdl, INodes, GMs>
 where
     Ms: 'static,
     Mdl: 'static,
-    ElC: View<Ms>,
+    INodes: IntoNodes<Ms>,
 {
     pub document: web_sys::Document,
     pub mount_point: web_sys::Element,
-    pub update: UpdateFn<Ms, Mdl, ElC, GMs>,
-    pub sink: Option<SinkFn<Ms, Mdl, ElC, GMs>>,
-    pub view: ViewFn<Mdl, ElC>,
+    pub update: UpdateFn<Ms, Mdl, INodes, GMs>,
+    pub sink: Option<SinkFn<Ms, Mdl, INodes, GMs>>,
+    pub view: ViewFn<Mdl, INodes>,
     pub window_events: Option<WindowEventsFn<Ms, Mdl>>,
 }

--- a/src/app/orders.rs
+++ b/src/app/orders.rs
@@ -1,5 +1,5 @@
 use super::{App, CmdHandle, RenderTimestampDelta, StreamHandle, SubHandle, UndefinedGMsg};
-use crate::virtual_dom::View;
+use crate::virtual_dom::IntoNodes;
 use futures::stream::Stream;
 use std::{any::Any, future::Future};
 
@@ -15,7 +15,7 @@ pub use proxy::OrdersProxy;
 pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     type AppMs: 'static;
     type Mdl: 'static;
-    type ElC: View<Self::AppMs> + 'static;
+    type INodes: IntoNodes<Self::AppMs> + 'static;
 
     /// Automatically map message type. It allows you to pass `Orders` into child module.
     ///
@@ -29,7 +29,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     fn proxy<ChildMs: 'static>(
         &mut self,
         f: impl FnOnce(ChildMs) -> Ms + 'static + Clone,
-    ) -> OrdersProxy<ChildMs, Self::AppMs, Self::Mdl, Self::ElC, GMs>;
+    ) -> OrdersProxy<ChildMs, Self::AppMs, Self::Mdl, Self::INodes, GMs>;
 
     /// Schedule web page rerender after model update. It's the default behaviour.
     fn render(&mut self) -> &mut Self;
@@ -125,7 +125,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ) -> CmdHandle;
 
     /// Get app instance. Cloning is cheap because `App` contains only `Rc` fields.
-    fn clone_app(&self) -> App<Self::AppMs, Self::Mdl, Self::ElC, GMs>;
+    fn clone_app(&self) -> App<Self::AppMs, Self::Mdl, Self::INodes, GMs>;
 
     /// Get function which maps module's `Msg` to app's (root's) one.
     ///

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -2,10 +2,12 @@ use super::OrdersContainer;
 use crate::browser::Url;
 use crate::virtual_dom::EventHandler;
 
-pub type InitFn<Ms, Mdl, ElC, GMs> = fn(Url, &mut OrdersContainer<Ms, Mdl, ElC, GMs>) -> Mdl;
-pub type UpdateFn<Ms, Mdl, ElC, GMs> = fn(Ms, &mut Mdl, &mut OrdersContainer<Ms, Mdl, ElC, GMs>);
-pub type SinkFn<Ms, Mdl, ElC, GMs> = fn(GMs, &mut Mdl, &mut OrdersContainer<Ms, Mdl, ElC, GMs>);
-pub type ViewFn<Mdl, ElC> = fn(&Mdl) -> ElC;
+pub type InitFn<Ms, Mdl, INodes, GMs> = fn(Url, &mut OrdersContainer<Ms, Mdl, INodes, GMs>) -> Mdl;
+pub type UpdateFn<Ms, Mdl, INodes, GMs> =
+    fn(Ms, &mut Mdl, &mut OrdersContainer<Ms, Mdl, INodes, GMs>);
+pub type SinkFn<Ms, Mdl, INodes, GMs> =
+    fn(GMs, &mut Mdl, &mut OrdersContainer<Ms, Mdl, INodes, GMs>);
+pub type ViewFn<Mdl, INodes> = fn(&Mdl) -> INodes;
 pub type RoutesFn<Ms> = fn(Url) -> Option<Ms>;
 pub type WindowEventsFn<Ms, Mdl> = fn(&Mdl) -> Vec<EventHandler<Ms>>;
 pub type MsgListeners<Ms> = Vec<Box<dyn Fn(&Ms)>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,8 @@ pub mod prelude {
         // https://github.com/rust-lang-nursery/reference/blob/master/src/macros-by-example.md
         shortcuts::*,
         virtual_dom::{
-            el_ref::el_ref, AsAtValue, At, AtValue, CSSValue, El, ElRef, Ev, EventHandler, Node,
-            St, Tag, ToClasses, UpdateEl, UpdateElForIterator, View,
+            el_ref::el_ref, AsAtValue, At, AtValue, CSSValue, El, ElRef, Ev, EventHandler,
+            IntoNodes, Node, St, Tag, ToClasses, UpdateEl, UpdateElForIterator, View,
         },
     };
     pub use indexmap::IndexMap; // for attrs and style to work.

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -329,6 +329,8 @@ macro_rules! style {
 #[macro_export]
 /// Converts items to `Vec<Node<Ms>` and returns flattened `Vec<Node<Ms>`.
 ///
+/// Items have to implement the trait `IntoNodes`.
+///
 /// # Example
 ///
 /// ```rust,no_run

--- a/src/virtual_dom/el_ref.rs
+++ b/src/virtual_dom/el_ref.rs
@@ -24,7 +24,7 @@ pub fn el_ref<E: Clone>(reference: &ElRef<E>) -> ElRef<E> {
 ///     canvas: ElRef<web_sys::HtmlCanvasElement>,
 /// }
 ///
-/// fn view(model: &Model) -> impl View<Msg> {
+/// fn view(model: &Model) -> impl IntoNodes<Msg> {
 ///     canvas![
 ///         el_ref(&model.canvas),
 ///         attrs![

--- a/src/virtual_dom/node.rs
+++ b/src/virtual_dom/node.rs
@@ -82,7 +82,7 @@ impl<Ms> Node<Ms> {
     }
 
     /// See `El::add_event_handler`
-    pub fn add_listener(&mut self, event_handler: EventHandler<Ms>) -> &mut Self {
+    pub fn add_event_handler(&mut self, event_handler: EventHandler<Ms>) -> &mut Self {
         if let Node::Element(el) = self {
             el.add_event_handler(event_handler);
         }

--- a/src/virtual_dom/node/into_nodes.rs
+++ b/src/virtual_dom/node/into_nodes.rs
@@ -1,6 +1,10 @@
 use super::Node;
 
+/// Items that implement `IntoNodes`:
+/// - Can be used in `nodes!`.
+/// - Can be returned from `view`.
 pub trait IntoNodes<Ms> {
+    /// Converts item or items to `Vec<Node<Ms>`.
     fn into_nodes(self) -> Vec<Node<Ms>>;
 }
 

--- a/src/virtual_dom/patch.rs
+++ b/src/virtual_dom/patch.rs
@@ -1,19 +1,19 @@
 //! This module contains code related to patching the VDOM. It can be considered
 //! a subset of the `vdom` module.
 
-use super::{El, Mailbox, Node, View};
+use super::{El, IntoNodes, Mailbox, Node};
 use crate::app::App;
 use crate::browser::dom::virtual_dom_bridge;
 use wasm_bindgen::JsCast;
 use web_sys::Document;
 
-fn patch_el<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
+fn patch_el<'a, Ms, Mdl, INodes: IntoNodes<Ms>, GMs>(
     document: &Document,
     mut old: El<Ms>,
     new: &'a mut El<Ms>,
     parent: &web_sys::Node,
     mailbox: &Mailbox<Ms>,
-    app: &App<Ms, Mdl, ElC, GMs>,
+    app: &App<Ms, Mdl, INodes, GMs>,
 ) -> Option<&'a web_sys::Node> {
     // At this step, we already assume we have the right element - either
     // by entering this func directly for the top-level, or recursively after
@@ -73,15 +73,15 @@ fn patch_el<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
     new.node_ws.as_ref()
 }
 
-pub(crate) fn patch_els<'a, Ms, Mdl, ElC, GMs, OI, NI>(
+pub(crate) fn patch_els<'a, Ms, Mdl, INodes, GMs, OI, NI>(
     document: &Document,
     mailbox: &Mailbox<Ms>,
-    app: &App<Ms, Mdl, ElC, GMs>,
+    app: &App<Ms, Mdl, INodes, GMs>,
     old_el_ws: &web_sys::Node,
     old_children_iter: OI,
     new_children_iter: NI,
 ) where
-    ElC: View<Ms>,
+    INodes: IntoNodes<Ms>,
     OI: ExactSizeIterator<Item = Node<Ms>>,
     NI: ExactSizeIterator<Item = &'a mut Node<Ms>>,
 {
@@ -175,14 +175,14 @@ fn add_el_helper<Ms>(
 
 /// Routes patching through different channels, depending on the Node variant
 /// of old and new.
-pub(crate) fn patch<'a, Ms, Mdl, ElC: View<Ms>, GMs>(
+pub(crate) fn patch<'a, Ms, Mdl, INodes: IntoNodes<Ms>, GMs>(
     document: &Document,
     old: Node<Ms>,
     new: &'a mut Node<Ms>,
     parent: &web_sys::Node,
     next_node: Option<web_sys::Node>,
     mailbox: &Mailbox<Ms>,
-    app: &App<Ms, Mdl, ElC, GMs>,
+    app: &App<Ms, Mdl, INodes, GMs>,
 ) -> Option<&'a web_sys::Node> {
     // Old_el_ws is what we're patching, with items from the new vDOM el; or replacing.
     // We go through each combination of new and old variants to determine how to patch.

--- a/src/virtual_dom/view.rs
+++ b/src/virtual_dom/view.rs
@@ -1,19 +1,8 @@
-use super::{El, Node};
+use super::{IntoNodes, Node};
 
-pub trait View<Ms> {
+#[deprecated(since = "0.7.0", note = "Use `IntoNodes` instead.")]
+pub trait View<Ms>: IntoNodes<Ms> {
     fn els(self) -> Vec<Node<Ms>>;
-}
-
-impl<Ms> View<Ms> for El<Ms> {
-    fn els(self) -> Vec<Node<Ms>> {
-        vec![Node::Element(self)]
-    }
-}
-
-impl<Ms> View<Ms> for Vec<El<Ms>> {
-    fn els(self) -> Vec<Node<Ms>> {
-        self.into_iter().map(Node::Element).collect()
-    }
 }
 
 impl<Ms> View<Ms> for Node<Ms> {


### PR DESCRIPTION
Changes
- [deprecated] `View` is deprecated in favor of `IntoNodes`.
- [BREAKING] `View` isn't implemented for `El` and `Vec<El>`.
- [BREAKING] `Node::add_listener` renamed to `add_event_handler`.

Motivation
 - There were some questions about `View` - what is it and when to use it. `IntoNodes` is more expressive and already in the code => it makes `View` redundant.
 - `add_listener` was forgotten during renaming `listeners` to `event_handlers`. 