### PR TITLE
Handlers accept Msg, Option<Msg> and ()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,10 @@
 - Added macros `C!` and `IF!` and helper `not` (#375).
 - Added trait `ToClasses` + included in the `prelude`.
 - Updated `todomvc` example to use `C!`, `IF!`, `matches!` and `App::start`.
-- `ev` accepts handlers that return `Msg` and `()` (#394).
+- `ev` accepts handlers that return `Msg`, `Option<Msg>` or `()` (#394).
 - [BREAKING] `EventHandler::new` accepts only handlers that return `Option<Msg>`.
 - [BREAKING] `ev`-like functions and some `Orders` method require `'static` bound for generic types (temporary). 
-- `Orders::after_next_render` now accepts callbacks that return `Msg` or `()`.
+- `Orders::after_next_render` now accepts callbacks that return `Msg`, `Option<Msg>` or `()`.
 - Updated examples `update_from_js` and `todomvc`.
 - [deprecated] `View` is deprecated in favor of `IntoNodes`.
 - [BREAKING] `View` isn't implemented for `El` and `Vec<El>`.

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -124,8 +124,6 @@ enum Msg {
     EditingTodoTitleChanged(String),
     SaveEditingTodo,
     CancelTodoEdit,
-
-    NoOp,
 }
 
 fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
@@ -204,8 +202,6 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
         Msg::CancelTodoEdit => {
             data.editing_todo = None;
         }
-
-        Msg::NoOp => (),
     }
     // Save data into LocalStorage. It should be optimized in a real-world application.
     storage::store_data(&model.services.local_storage, STORAGE_KEY, &data);
@@ -249,11 +245,7 @@ fn view_header(new_todo_title: &str) -> Node<Msg> {
                 At::Value => new_todo_title;
             },
             keyboard_ev(Ev::KeyDown, |keyboard_event| {
-                if keyboard_event.key_code() == ENTER_KEY {
-                    Msg::CreateNewTodo
-                } else {
-                    Msg::NoOp
-                }
+                IF!(keyboard_event.key_code() == ENTER_KEY => Msg::CreateNewTodo)
             }),
             input_ev(Ev::Input, Msg::NewTodoTitleChanged),
         ]
@@ -351,14 +343,10 @@ fn view_todo(
                     ev(Ev::Blur, |_| Msg::SaveEditingTodo),
                     input_ev(Ev::Input, Msg::EditingTodoTitleChanged),
                     keyboard_ev(Ev::KeyDown, |keyboard_event| {
-                        // @TODO rafactor to `match` once it can accept constants
-                        let code = keyboard_event.key_code();
-                        if code == ENTER_KEY {
-                            Msg::SaveEditingTodo
-                        } else if code == ESC_KEY {
-                            Msg::CancelTodoEdit
-                        } else {
-                            Msg::NoOp
+                        match keyboard_event.key_code() {
+                            ENTER_KEY => Some(Msg::SaveEditingTodo),
+                            ESC_KEY => Some(Msg::CancelTodoEdit),
+                            _ => None,
                         }
                     }),
                 ]

--- a/src/app/cmds.rs
+++ b/src/app/cmds.rs
@@ -7,7 +7,7 @@ use gloo_timers::future::TimeoutFuture;
 
 /// Set timeout in milliseconds.
 ///
-/// Handler has to return `Msg` or `()`.
+/// Handler has to return `Msg`, `Option<Msg>` or `()`.
 ///
 /// # Example
 ///
@@ -18,7 +18,8 @@ use gloo_timers::future::TimeoutFuture;
 ///
 /// # Panics
 ///
-/// Panics when the command doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+/// Panics when the command doesn't return `Msg`, `Option<Msg>` or `()`.
+/// (It will be changed to a compile-time error).
 pub fn timeout<MsU>(
     ms: u32,
     handler: impl FnOnce() -> MsU + Clone + 'static,

--- a/src/app/orders.rs
+++ b/src/app/orders.rs
@@ -40,7 +40,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     /// Don't rerender web page after model update.
     fn skip(&mut self) -> &mut Self;
 
-    /// Notify all subscription handlers which listen for messages with the `message`'s type.
+    /// Notify all subscription handlers that listen for messages with the `message`'s type.
     ///
     /// # Example
     ///
@@ -66,7 +66,9 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     /// _Note:_: All `msg`s are pushed to the queue - i.e. `update` function is NOT called immediately.
     fn send_msg(&mut self, msg: Ms) -> &mut Self;
 
-    /// Execute given future `cmd` and send its output (`Msg`) to `update` function.
+    /// Execute `cmd` and send its output (if it's `Msg`) to `update` function.
+    ///
+    /// Output has to be `Msg`, `Option<Msg>` or `()`.
     ///
     /// # Example
     ///
@@ -79,15 +81,18 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// # Panics
     ///
-    /// Panics when handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the output isn't `Msg`, `Option<Msg>` or `()`.
+    /// (It will be changed to a compile-time error).
     #[allow(clippy::shadow_unrelated)]
-    // @TODO remove `'static`s once `optin_builtin_traits`
+    // @TODO remove `'static`s once `optin_builtin_traits`, `negative_impls`
     // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
     fn perform_cmd<MsU: 'static>(&mut self, cmd: impl Future<Output = MsU> + 'static) -> &mut Self;
 
-    /// Execute given future `cmd` and send its output (`Msg`) to `update` function.
+    /// Execute given `cmd` and send its output (if it's `Msg`) to `update` function.
     /// - Returns `CmdHandle` that you should save to your `Model`.
     ///   The `cmd` is aborted on the handle drop.
+    ///
+    /// Output has to be `Msg`, `Option<Msg>` or `()`.
     ///
     /// # Example
     ///
@@ -98,10 +103,11 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// # Panics
     ///
-    /// Panics when the command doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the output isn't `Msg`, `Option<Msg>` or `()`.
+    /// (It will be changed to a compile-time error).
     #[must_use = "cmd is aborted on its handle drop"]
     #[allow(clippy::shadow_unrelated)]
-    // @TODO remove `'static`s once `optin_builtin_traits`
+    // @TODO remove `'static`s once `optin_builtin_traits`, `negative_impls`
     // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
     fn perform_cmd_with_handle<MsU: 'static>(
         &mut self,
@@ -127,7 +133,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     /// Get app instance. Cloning is cheap because `App` contains only `Rc` fields.
     fn clone_app(&self) -> App<Self::AppMs, Self::Mdl, Self::INodes, GMs>;
 
-    /// Get function which maps module's `Msg` to app's (root's) one.
+    /// Get the function that maps module's `Msg` to app's (root's) one.
     ///
     /// # Example
     ///
@@ -145,16 +151,17 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// - It's useful when you want to use DOM API or make animations.
     /// - You can call this function multiple times - callbacks will be executed in the same order.
-    /// - Callback has to return `Msg` or `()`.
+    /// - Callback has to return `Msg`, `Option<Msg>` or `()`.
     ///
     /// _Note:_ [performance.now()](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now)
     ///  is used under the hood to get timestamps.
     ///
     /// # Panics
     ///
-    /// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the handler doesn't return `Msg`, `Option<Msg>` or `()`.
+    /// (It will be changed to a compile-time error).
     #[allow(clippy::shadow_unrelated)]
-    // @TODO remove `'static`s once `optin_builtin_traits`
+    // @TODO remove `'static`s once `optin_builtin_traits`, `negative_impls`
     // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
     fn after_next_render<MsU: 'static>(
         &mut self,
@@ -163,7 +170,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
 
     /// Subscribe for messages with the `handler`s input type.
     ///
-    /// Handler has to return `Msg` or `()`.
+    /// Handler has to return `Msg`, `Option<Msg>` or `()`.
     ///
     /// # Example
     ///
@@ -180,9 +187,10 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// # Panics
     ///
-    /// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the handler doesn't return `Msg`, `Option<Msg>` or `()`.
+    /// (It will be changed to a compile-time error).
     #[allow(clippy::shadow_unrelated)]
-    // @TODO remove `'static`s once `optin_builtin_traits`
+    // @TODO remove `'static`s once `optin_builtin_traits`, `negative_impls`
     // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
     fn subscribe<MsU: 'static, SubMs: 'static + Clone>(
         &mut self,
@@ -193,7 +201,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     /// - Returns `SubHandle` that you should save to your `Model`.
     ///   The `sub` is cancelled on the handle drop.
     ///
-    /// Handler has to return `Msg` or `()`.
+    /// Handler has to return `Msg`, `Option<Msg>` or `()`.
     ///
     /// # Example
     ///
@@ -208,17 +216,18 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// # Panics
     ///
-    /// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the handler doesn't return `Msg`, `Option<Msg>` or `()`.
+    /// (It will be changed to a compile-time error).
     #[must_use = "subscription is cancelled on its handle drop"]
     #[allow(clippy::shadow_unrelated)]
-    // @TODO remove `'static`s once `optin_builtin_traits`
+    // @TODO remove `'static`s once `optin_builtin_traits`, `negative_impls`
     // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
     fn subscribe_with_handle<MsU: 'static, SubMs: 'static + Clone>(
         &mut self,
         handler: impl FnOnce(SubMs) -> MsU + Clone + 'static,
     ) -> SubHandle;
 
-    /// Stream `Msg`s or `()`s.
+    /// Stream `Msg`, `Option<Msg>` or `()`.
     ///
     /// # Example
     ///
@@ -231,13 +240,14 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// # Panics
     ///
-    /// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the handler doesn't return `Msg`, `Option<Msg>` or `()`.
+    /// (It will be changed to a compile-time error).
     #[allow(clippy::shadow_unrelated)]
-    // @TODO remove `'static`s once `optin_builtin_traits`
+    // @TODO remove `'static`s once `optin_builtin_traits`, `negative_impls`
     // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
     fn stream<MsU: 'static>(&mut self, stream: impl Stream<Item = MsU> + 'static) -> &mut Self;
 
-    /// Stream `Msg`s or `()`s.
+    /// Stream `Msg`, `Option<Msg>` or `()`.
     /// - Returns `StreamHandle` that you should save to your `Model`.
     ///   The `stream` is cancelled on the handle drop.
     ///
@@ -250,10 +260,11 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
     ///
     /// # Panics
     ///
-    /// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+    /// Panics when the handler doesn't return `Msg`, `Option<Msg>` or `()`.
+    /// (It will be changed to a compile-time error).
     #[must_use = "stream is stopped on its handle drop"]
     #[allow(clippy::shadow_unrelated)]
-    // @TODO remove `'static`s once `optin_builtin_traits`
+    // @TODO remove `'static`s once `optin_builtin_traits`, `negative_impls`
     // @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
     fn stream_with_handle<MsU: 'static>(
         &mut self,

--- a/src/app/streams.rs
+++ b/src/app/streams.rs
@@ -5,7 +5,7 @@ use gloo_timers::future::IntervalStream;
 
 /// Stream no values on predefined time interval in milliseconds.
 ///
-/// Handler has to return `Msg` or `()`.
+/// Handler has to return `Msg`, `Option<Msg>` or `()`.
 ///
 /// # Example
 ///
@@ -16,7 +16,8 @@ use gloo_timers::future::IntervalStream;
 ///
 /// # Panics
 ///
-/// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+/// Panics when the handler doesn't return `Msg`, `Option<Msg>` or `()`.
+/// (It will be changed to a compile-time error).
 pub fn interval<MsU>(
     ms: u32,
     handler: impl FnOnce() -> MsU + Clone + 'static,

--- a/src/app/streams/window_event.rs
+++ b/src/app/streams/window_event.rs
@@ -12,7 +12,7 @@ use web_sys::{Event, EventTarget};
 
 /// Stream `Window` `web_sys::Event`s.
 ///
-/// Handler has to return `Msg` or `()`.
+/// Handler has to return `Msg`, `Option<Msg>` or `()`.
 ///
 /// # Example
 ///
@@ -23,7 +23,8 @@ use web_sys::{Event, EventTarget};
 ///
 /// # Panics
 ///
-/// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
+/// Panics when the handler doesn't return `Msg`, `Option<Msg>` or `()`.
+/// (It will be changed to a compile-time error).
 pub fn window_event<MsU>(
     trigger: impl Into<Ev>,
     handler: impl FnOnce(Event) -> MsU + Clone + 'static,

--- a/src/browser/dom/event_handler.rs
+++ b/src/browser/dom/event_handler.rs
@@ -4,27 +4,22 @@
 use super::super::util;
 use crate::virtual_dom::{Ev, EventHandler};
 use std::any::{Any, TypeId};
+use std::rc::Rc;
 use wasm_bindgen::JsCast;
 
 /// Create an event that passes a String of field text, for fast input handling.
 #[allow(clippy::shadow_unrelated)]
-// @TODO remove `'static`s once `optin_builtin_traits`
-// @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
 pub fn input_ev<Ms: 'static, MsU: 'static>(
     trigger: impl Into<Ev>,
     handler: impl FnOnce(String) -> MsU + 'static + Clone,
 ) -> EventHandler<Ms> {
-    // @TODO refactor once `optin_builtin_traits` is stable (https://github.com/seed-rs/seed/issues/391)
-    let t_type = TypeId::of::<MsU>();
-    if t_type != TypeId::of::<Ms>() && t_type != TypeId::of::<()>() {
-        panic!("Handler can return only Msg or ()!");
-    }
-    let handler = move |text| {
-        let output = &mut Some(handler.clone()(text)) as &mut dyn Any;
-        output.downcast_mut::<Option<Ms>>().and_then(Option::take)
-    };
-
-    let closure_handler = move |event: web_sys::Event| {
+    let handler = map_callback_return_to_option_ms!(
+        dyn Fn(String) -> Option<Ms>,
+        handler.clone(),
+        "Handler can return only Msg, Option<Msg> or ()!",
+        Rc
+    );
+    let handler = move |event: web_sys::Event| {
         let value = event
             .target()
             .as_ref()
@@ -34,87 +29,67 @@ pub fn input_ev<Ms: 'static, MsU: 'static>(
             .unwrap_or_default();
         handler(value)
     };
-    EventHandler::new(trigger, closure_handler)
+    EventHandler::new(trigger, handler)
 }
 
 /// Create an event that passes a `web_sys::KeyboardEvent`, allowing easy access
 /// to items like `key_code`() and key().
 #[allow(clippy::shadow_unrelated)]
-// @TODO remove `'static`s once `optin_builtin_traits`
-// @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
 pub fn keyboard_ev<Ms: 'static, MsU: 'static>(
     trigger: impl Into<Ev>,
     handler: impl FnOnce(web_sys::KeyboardEvent) -> MsU + 'static + Clone,
 ) -> EventHandler<Ms> {
-    // @TODO refactor once `optin_builtin_traits` is stable (https://github.com/seed-rs/seed/issues/391)
-    let t_type = TypeId::of::<MsU>();
-    if t_type != TypeId::of::<Ms>() && t_type != TypeId::of::<()>() {
-        panic!("Handler can return only Msg or ()!");
-    }
-    let handler = move |event| {
-        let output = &mut Some(handler.clone()(event)) as &mut dyn Any;
-        output.downcast_mut::<Option<Ms>>().and_then(Option::take)
-    };
-
-    let closure_handler = move |event: web_sys::Event| {
+    let handler = map_callback_return_to_option_ms!(
+        dyn Fn(web_sys::KeyboardEvent) -> Option<Ms>,
+        handler.clone(),
+        "Handler can return only Msg, Option<Msg> or ()!",
+        Rc
+    );
+    let handler = move |event: web_sys::Event| {
         handler(event.dyn_ref::<web_sys::KeyboardEvent>().unwrap().clone())
     };
-    EventHandler::new(trigger, closure_handler)
+    EventHandler::new(trigger, handler)
 }
 
 /// See `keyboard_ev`
 #[allow(clippy::shadow_unrelated)]
-// @TODO remove `'static`s once `optin_builtin_traits`
-// @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
 pub fn mouse_ev<Ms: 'static, MsU: 'static>(
     trigger: impl Into<Ev>,
     handler: impl FnOnce(web_sys::MouseEvent) -> MsU + 'static + Clone,
 ) -> EventHandler<Ms> {
-    // @TODO refactor once `optin_builtin_traits` is stable (https://github.com/seed-rs/seed/issues/391)
-    let t_type = TypeId::of::<MsU>();
-    if t_type != TypeId::of::<Ms>() && t_type != TypeId::of::<()>() {
-        panic!("Handler can return only Msg or ()!");
-    }
-    let handler = move |event| {
-        let output = &mut Some(handler.clone()(event)) as &mut dyn Any;
-        output.downcast_mut::<Option<Ms>>().and_then(Option::take)
-    };
-
-    let closure_handler = move |event: web_sys::Event| {
+    let handler = map_callback_return_to_option_ms!(
+        dyn Fn(web_sys::MouseEvent) -> Option<Ms>,
+        handler.clone(),
+        "Handler can return only Msg, Option<Msg> or ()!",
+        Rc
+    );
+    let handler = move |event: web_sys::Event| {
         handler(event.dyn_ref::<web_sys::MouseEvent>().unwrap().clone())
     };
-    EventHandler::new(trigger, closure_handler)
+    EventHandler::new(trigger, handler)
 }
 
 /// See `keyboard_ev`
 #[allow(clippy::shadow_unrelated)]
-// @TODO remove `'static`s once `optin_builtin_traits`
-// @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
 pub fn pointer_ev<Ms: 'static, MsU: 'static>(
     trigger: impl Into<Ev>,
     handler: impl FnOnce(web_sys::PointerEvent) -> MsU + 'static + Clone,
 ) -> EventHandler<Ms> {
-    // @TODO refactor once `optin_builtin_traits` is stable (https://github.com/seed-rs/seed/issues/391)
-    let t_type = TypeId::of::<MsU>();
-    if t_type != TypeId::of::<Ms>() && t_type != TypeId::of::<()>() {
-        panic!("Handler can return only Msg or ()!");
-    }
-    let handler = move |event| {
-        let output = &mut Some(handler.clone()(event)) as &mut dyn Any;
-        output.downcast_mut::<Option<Ms>>().and_then(Option::take)
-    };
-
-    let closure_handler = move |event: web_sys::Event| {
+    let handler = map_callback_return_to_option_ms!(
+        dyn Fn(web_sys::PointerEvent) -> Option<Ms>,
+        handler.clone(),
+        "Handler can return only Msg, Option<Msg> or ()!",
+        Rc
+    );
+    let handler = move |event: web_sys::Event| {
         handler(event.dyn_ref::<web_sys::PointerEvent>().unwrap().clone())
     };
-    EventHandler::new(trigger, closure_handler)
+    EventHandler::new(trigger, handler)
 }
 
 /// Create an event that accepts a closure, and passes a `web_sys::Event`, allowing full control of
 /// event-handling.
 #[deprecated(since = "0.6.0", note = "Use `ev` instead.")]
-// @TODO remove `'static`s once `optin_builtin_traits`
-// @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
 pub fn raw_ev<Ms: 'static, MsU: 'static>(
     trigger: impl Into<Ev>,
     handler: impl FnOnce(web_sys::Event) -> MsU + 'static + Clone,
@@ -125,30 +100,23 @@ pub fn raw_ev<Ms: 'static, MsU: 'static>(
 /// Create an event handler that accepts a closure, and passes a `web_sys::Event`, allowing full control of
 /// event-handling.
 ///
-/// Handler has to return `Msg` or `()`.
+/// Handler has to return `Msg`, `Option<Msg>` or `()`.
 ///
 /// # Panics
 ///
 /// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
 #[allow(clippy::shadow_unrelated)]
-// @TODO remove `'static`s once `optin_builtin_traits`
-// @TODO or https://github.com/rust-lang/rust/issues/41875 is stable
 pub fn ev<Ms: 'static, MsU: 'static>(
     trigger: impl Into<Ev>,
     handler: impl FnOnce(web_sys::Event) -> MsU + 'static + Clone,
 ) -> EventHandler<Ms> {
-    // @TODO refactor once `optin_builtin_traits` is stable (https://github.com/seed-rs/seed/issues/391)
-    let t_type = TypeId::of::<MsU>();
-    if t_type != TypeId::of::<Ms>() && t_type != TypeId::of::<()>() {
-        panic!("Handler can return only Msg or ()!");
-    }
-    let handler = move |event| {
-        let output = &mut Some(handler.clone()(event)) as &mut dyn Any;
-        output.downcast_mut::<Option<Ms>>().and_then(Option::take)
-    };
-
-    let closure_handler = move |event: web_sys::Event| handler(event);
-    EventHandler::new(trigger, closure_handler)
+    let handler = map_callback_return_to_option_ms!(
+        dyn Fn(web_sys::Event) -> Option<Ms>,
+        handler.clone(),
+        "Handler can return only Msg, Option<Msg> or ()!",
+        Rc
+    );
+    EventHandler::new(trigger, move |event| handler(event))
 }
 
 /// Create an event that passes no data, other than it occurred. Foregoes using a closure,


### PR DESCRIPTION
Handlers accept Msg, **Option\<Msg\>** and ().

Motivation:
See copy-pasted code from updated `todomvc` example below:
```rust
keyboard_ev(Ev::KeyDown, |keyboard_event| {
    IF!(keyboard_event.key_code() == ENTER_KEY => Msg::CreateNewTodo)
}),
...
keyboard_ev(Ev::KeyDown, |keyboard_event| {
    match keyboard_event.key_code() {
         ENTER_KEY => Some(Msg::SaveEditingTodo),
         ESC_KEY => Some(Msg::CancelTodoEdit),
         _ => None,
     }
 }),
```