### PR TITLE
fix: Reset checked and value on attribute remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Implemented `IntoNodes` for `Option<Node<Msg>>` and `Option<Vec<Node<Msg>>>`.
 - Added example `graphql` (#400).
 - Implemented `UpdateEl` for `i64` and `u64`.
+- Reset properties `checked` and `value` on attribute remove (#405). 
 
 ## v0.6.0
 - Implemented `UpdateEl` for `Filter` and `FilterMap`.


### PR DESCRIPTION
Resolves #405 

We mirror `value` and `checked` attributes to properties while we are adding attributes, but we forgot to do the same while removing attributes.