### PR TITLE
re-render on EventHandler callback even if EventHandler's callback returns `()` or `None`.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -534,8 +534,12 @@ impl<Ms, Mdl, INodes: IntoNodes<Ms> + 'static, GMs: 'static> App<Ms, Mdl, INodes
     }
 
     fn mailbox(&self) -> Mailbox<Ms> {
-        Mailbox::new(enclose!((self => s) move |message| {
-            s.update(message);
+        Mailbox::new(enclose!((self => s) move |option_message| {
+            if let Some(message) = option_message {
+                s.update(message);
+            } else {
+                s.rerender_vdom();
+            }
         }))
     }
 
@@ -630,6 +634,7 @@ impl<Ms, Mdl, INodes: IntoNodes<Ms> + 'static, GMs: 'static> App<Ms, Mdl, INodes
         //  - didn't force-rerender vdom
         //  - didn't schedule render
         //  - doesn't want to skip render
+
         self.rerender_vdom();
 
         self

--- a/src/browser/dom.rs
+++ b/src/browser/dom.rs
@@ -46,7 +46,7 @@ pub mod tests {
             &mut node,
             &parent,
             None,
-            &Mailbox::new(|_: Msg| {}),
+            &Mailbox::new(|_: Option<Msg>| {}),
             &app,
         );
 

--- a/src/virtual_dom.rs
+++ b/src/virtual_dom.rs
@@ -74,7 +74,7 @@ pub mod tests {
     #[wasm_bindgen_test]
     fn el_added() {
         let app = create_app();
-        let mailbox = Mailbox::new(|_msg: Msg| {});
+        let mailbox = Mailbox::new(|_msg: Option<Msg>| {});
 
         let doc = util::document();
         let parent = doc.create_element("div").expect("parent");
@@ -146,7 +146,7 @@ pub mod tests {
     #[wasm_bindgen_test]
     fn el_removed() {
         let app = create_app();
-        let mailbox = Mailbox::new(|_msg: Msg| {});
+        let mailbox = Mailbox::new(|_msg: Option<Msg>| {});
 
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
@@ -185,7 +185,7 @@ pub mod tests {
     #[wasm_bindgen_test]
     fn el_changed() {
         let app = create_app();
-        let mailbox = Mailbox::new(|_msg: Msg| {});
+        let mailbox = Mailbox::new(|_msg: Option<Msg>| {});
 
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
@@ -246,7 +246,7 @@ pub mod tests {
     #[wasm_bindgen_test]
     fn els_changed_correct_order() {
         let app = create_app();
-        let mailbox = Mailbox::new(|_msg: Msg| {});
+        let mailbox = Mailbox::new(|_msg: Option<Msg>| {});
 
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
@@ -274,7 +274,7 @@ pub mod tests {
     #[wasm_bindgen_test]
     fn attr_disabled() {
         let app = create_app();
-        let mailbox = Mailbox::new(|_msg: Msg| {});
+        let mailbox = Mailbox::new(|_msg: Option<Msg>| {});
 
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
@@ -356,7 +356,7 @@ pub mod tests {
     #[wasm_bindgen_test]
     fn empty_changed_in_front() {
         let app = create_app();
-        let mailbox = Mailbox::new(|_msg: Msg| {});
+        let mailbox = Mailbox::new(|_msg: Option<Msg>| {});
 
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
@@ -408,7 +408,7 @@ pub mod tests {
     #[wasm_bindgen_test]
     fn empty_changed_in_the_middle() {
         let app = create_app();
-        let mailbox = Mailbox::new(|_msg: Msg| {});
+        let mailbox = Mailbox::new(|_msg: Option<Msg>| {});
 
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
@@ -459,7 +459,7 @@ pub mod tests {
     #[wasm_bindgen_test]
     fn root_empty_changed() {
         let app = create_app();
-        let mailbox = Mailbox::new(|_msg: Msg| {});
+        let mailbox = Mailbox::new(|_msg: Option<Msg>| {});
 
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
@@ -493,7 +493,7 @@ pub mod tests {
     #[wasm_bindgen_test]
     fn root_empty_to_empty() {
         let app = create_app();
-        let mailbox = Mailbox::new(|_msg: Msg| {});
+        let mailbox = Mailbox::new(|_msg: Option<Msg>| {});
 
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();
@@ -507,7 +507,7 @@ pub mod tests {
     #[wasm_bindgen_test]
     fn text_to_element_to_text() {
         let app = create_app();
-        let mailbox = Mailbox::new(|_msg: Msg| {});
+        let mailbox = Mailbox::new(|_msg: Option<Msg>| {});
 
         let doc = util::document();
         let parent = doc.create_element("div").unwrap();

--- a/src/virtual_dom/event_handler_manager/listener.rs
+++ b/src/virtual_dom/event_handler_manager/listener.rs
@@ -45,9 +45,8 @@ impl<Ms> Listener<Ms> {
                     event_handlers
                 });
                 for handler_callback in handler_callbacks {
-                    if let Some(msg) = handler_callback(event.clone()) {
-                        mailbox.send(msg);
-                    }
+                    let msg = handler_callback(event.clone());
+                    mailbox.send(msg);
                 }
             }),
         );

--- a/src/virtual_dom/mailbox.rs
+++ b/src/virtual_dom/mailbox.rs
@@ -1,17 +1,17 @@
 use std::rc::Rc;
 
 pub struct Mailbox<Message: 'static> {
-    func: Rc<dyn Fn(Message)>,
+    func: Rc<dyn Fn(Option<Message>)>,
 }
 
 impl<Ms> Mailbox<Ms> {
-    pub fn new(func: impl Fn(Ms) + 'static) -> Self {
+    pub fn new(func: impl Fn(Option<Ms>) + 'static) -> Self {
         Mailbox {
             func: Rc::new(func),
         }
     }
 
-    pub fn send(&self, message: Ms) {
+    pub fn send(&self, message: Option<Ms>) {
         (self.func)(message)
     }
 }


### PR DESCRIPTION
Achieved by allowing Mailbox to accept `Option<Msg>`.

this allows 'App::rerender_vdom()' to be directly called if the mailbox is processing `None`.

