### PR TITLE
Libdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,50 @@
 //! Visit the [website](https://seed-rs.org/)
 //!
 //! See the [github Readme](https://github.com/seed-rs/seed) for details
+//!
+//!
+//! ## Counter Example
+//! ```
+//! use seed::{prelude::*, *};
+//!
+//! // `init` describes what should happen when your app started.
+//! fn init(_: Url, _: &mut impl Orders<Msg>) -> Model {
+//!     Model::default()
+//! }
+//!
+//! // `Model` describes our app state.
+//! type Model = i32;
+//!
+//! // `Msg` describes the different events you can modify state with.
+//! enum Msg {
+//!     Increment,
+//! }
+//!
+//! // `update` describes how to handle each `Msg`.
+//! fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
+//!     match msg {
+//!         Msg::Increment => *model += 1,
+//!     }
+//! }
+//!
+//! // `view` describes what to display.
+//! fn view(model: &Model) -> Node<Msg> {
+//!     div![
+//!         "This is a counter: ",
+//!         C!["counter"],
+//!         button![
+//!             model,
+//!             ev(Ev::Click, |_| Msg::Increment),
+//!         ],
+//!     ]
+//! }
+//!
+//! #[wasm_bindgen(start)]
+//! pub fn start() {
+//!     // Mount the `app` to the element with the `id` "app".
+//!     App::start("app", init, update, view);
+//! }
+//! ```
 
 //#![deny(missing_docs)]
 #![forbid(unsafe_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
-//! See readme for details.
+//! Visit the [website](https://seed-rs.org/)
+//!
+//! See the [github Readme](https://github.com/seed-rs/seed) for details
 
 //#![deny(missing_docs)]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
At the crate [documentation](https://docs.rs/seed/0.6.0/seed/), the top just says "See readme for details."

To be more ergonomic and helpful, I've added a link to the crate website, and the github (which also has the Readme), and brought in the Counter Example. 

No changes to the source code was made. 

It should be the case that the only changes outside documentation is with `cargo test --doc`. No changes to other doc-tests. new doc-test passes.