### PR TITLE
Allow to patch custom elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 [unreleased]
+- [BREAKING] Custom elements are now patched in-place (#364). Use `el_key` to force reinitialize an element.
 - Added `el_key` method for adding keys to `El`s (#354).
 - Enabled all additional markdown [extensions](https://docs.rs/pulldown-cmark/latest/pulldown_cmark/struct.Options.html).
 - Removed `'static` bound from `El` and `Node`.

--- a/src/virtual_dom/patch/patch_gen.rs
+++ b/src/virtual_dom/patch/patch_gen.rs
@@ -450,12 +450,7 @@ where
 
 /// Checks whether the old element can be updated with a new one.
 pub(crate) fn el_can_be_patched<Ms>(el_old: &El<Ms>, el_new: &El<Ms>) -> bool {
-    // Custom elements can't be patched, because we need to reinit them (Issue #325).
-    // @TODO remove this check when #364 will be done.
-    el_old.namespace == el_new.namespace
-        && el_old.tag == el_new.tag
-        && el_old.key == el_new.key
-        && !el_new.is_custom()
+    el_old.namespace == el_new.namespace && el_old.tag == el_new.tag && el_old.key == el_new.key
 }
 
 /// Takes children from source iterators (new and old) and puts them in the


### PR DESCRIPTION
Disabling patch for custom elements was introduced as a fix for #325 #328.
I propose another solution using an observer (see https://github.com/seed-rs/seed-rs.org/pull/46).

This will allow the use of custom elements with an internal state.

Solves #364