### PR TITLE
Clean up clippy lints. (nightly)

### DIFF
--- a/src/browser/web_socket/builder.rs
+++ b/src/browser/web_socket/builder.rs
@@ -9,7 +9,7 @@ use web_sys::MessageEvent;
 
 // `Callbacks` are used internally by `WebSocket` and `Builder`.
 #[derive(Default, Debug)]
-pub(crate) struct Callbacks {
+pub struct Callbacks {
     pub on_open: Option<Closure<dyn Fn(JsValue)>>,
     pub on_close: Option<Closure<dyn Fn(JsValue)>>,
     pub on_error: Option<Closure<dyn Fn(JsValue)>>,

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -497,7 +497,7 @@ macro_rules! nodes {
 //}
 
 #[cfg(use_nightly)]
-pub fn wrap_debug<T>(object: T) -> dbg::WrapDebug<T> {
+pub const fn wrap_debug<T>(object: T) -> dbg::WrapDebug<T> {
     dbg::WrapDebug(object)
 }
 

--- a/src/virtual_dom/patch/patch_gen.rs
+++ b/src/virtual_dom/patch/patch_gen.rs
@@ -77,7 +77,7 @@ use std::collections::{BTreeSet, VecDeque};
 use std::iter::Peekable;
 
 #[allow(clippy::large_enum_variant)]
-pub(crate) enum PatchCommand<'a, Ms: 'static> {
+pub enum PatchCommand<'a, Ms: 'static> {
     AppendEl {
         el_new: &'a mut El<Ms>,
     },
@@ -149,7 +149,7 @@ impl PatchKey {
 
 /// This is a command generator.
 /// See the module documenation for brief description of how this works.
-pub(crate) struct PatchGen<'a, Ms, OI, NI>
+pub struct PatchGen<'a, Ms, OI, NI>
 where
     Ms: 'static,
     OI: Iterator<Item = Node<Ms>>,
@@ -449,7 +449,7 @@ where
 }
 
 /// Checks whether the old element can be updated with a new one.
-pub(crate) fn el_can_be_patched<Ms>(el_old: &El<Ms>, el_new: &El<Ms>) -> bool {
+pub fn el_can_be_patched<Ms>(el_old: &El<Ms>, el_new: &El<Ms>) -> bool {
     el_old.namespace == el_new.namespace && el_old.tag == el_new.tag && el_old.key == el_new.key
 }
 


### PR DESCRIPTION
Clippy showed up a pair of redundant visibilites ([explination](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pub_crate)), and a [missing_const_for_fn](https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn)