### PR TITLE
Proposal: Add more documentation, along with consolidating the module structure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,16 +89,16 @@ macro_rules! map_callback_return_to_option_ms {
 // @TODO move to prelude (?)
 pub use crate::{
     app::{App, AppBuilder},
-    browser::dom::cast::{
-        to_drag_event, to_html_el, to_input, to_keyboard_event, to_mouse_event, to_select,
-        to_textarea, to_touch_event,
-    },
+    // browser::dom::cast::{
+    //     to_drag_event, to_html_el, to_input, to_keyboard_event, to_mouse_event, to_select,
+    //     to_textarea, to_touch_event,
+    // },
     browser::fetch,
     browser::service::routing::push_route,
     browser::service::storage,
     browser::url::Url,
     browser::util::{
-        self, body, canvas, canvas_context_2d, cookies, document, error, history, html_document,
+        self, /* body, */ canvas, canvas_context_2d, cookies, document, error, history, html_document,
         log, window,
     },
     virtual_dom::{Attrs, EventHandler, Style},
@@ -106,12 +106,27 @@ pub use crate::{
 pub use futures::future::{FutureExt, TryFutureExt};
 use wasm_bindgen::{closure::Closure, JsCast};
 
+pub mod dom {
+    //! Features for working with the DOM
+    //!
+    //! This module exports functions and other Seed features that work with the browser
+    //! DOM directly. It's generally preferred to use the virtual DOM where possible
+
+
+    #[doc(inline)]
+    pub use crate::browser::dom::cast::*;
+
+    #[doc(inline)]
+    pub use crate::browser::util::body;
+}
+
 #[macro_use]
 pub mod shortcuts;
 pub mod app;
 pub mod browser;
 pub mod dom_entity_names;
 pub mod helpers;
+/// Modelling and manipulation of performant [virtual DOM](https://elm-lang.org/news/blazing-fast-html#virtual-dom)
 pub mod virtual_dom;
 
 /// Create an element flagged in a way that it will not be rendered. Useful


### PR DESCRIPTION
## Suggested Changes

The libraries documentation leaves room to take advantage of the rusts doc tooling. This proposal shows two examples.

1. In-line documentation of modules at the crate root
2. Consolidating deep namespaces

## Why

#### In line documentation

At the root, it outlines top-level modules. These can make for for valuable 1 or 2 line comments. This can serve the valuable role of providing an overview of the APIs structure, and add context for how it's intended to be used.

#### Consolidation of namespaces

The list of re-exports at documentation don't add context to what's being exported. In this proposal, we add the `dom` module, provide context of what the module provides, and move re-exports into it. 

With this repeated for other re-exports, it will allow the front page to focus on providing context, with details intuitively organized into modules.

## Resolving Breaking Changes

There won't be any changes to the functionality of the library. Breaking changes would come from changes to the layout of the API. Internally, this is not of significant concern - the examples in this proposal were relatively trivial to put together, and don't break `cargo make verify`. Other changes were not so straight forward, though. 

Externally, the implications of these changes to the API structure are another matter. I'll leave it up to comments to propose how this could be managed

## Possible Implementation

The changes provided in this proposal PR were directly inspired by the way [rocket](https://rocket.rs/) handles its module and namespace structure. See the [code linked](https://github.com/SergioBenitez/Rocket/blob/1010f6a2a88fac899dec0cd2f642156908038a53/core/lib/src/lib.rs#L112) for an example.

## Next Steps

Immediately, there is nothing technical getting in the way of filling out the module inline documentation.

More ambitiously, consolidating the the module structure would be done along with adding to documentation. Given that this will impact the public API, this will need to be done carefully. There are other efforts underway to make changes to the API.

Integrating module consolidation into these plans, and discussion of what the final structure would be a good first start, I think.