### PR TITLE
fix: Base path with a trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
-[unreleased]
+
+## [unreleased]
 - [BREAKING] Rename `linear_gradient!` to `linearGradient!` for consistency with the other svg macros (same with `radial_gradient!` and `mesh_gradient!`).
+- Fixed `base_path` with a trailing slash parsing / handling.
 
 ## v0.7.0
 - [BREAKING] Custom elements are now patched in-place (#364). Use `el_key` to force reinitialize an element.

--- a/examples/pages/index.html
+++ b/examples/pages/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-  <base href="/base/path">
+  <base href="/base/path/">
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <title>Pages example</title>

--- a/examples/url/index.html
+++ b/examples/url/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-  <base href="ui">
+  <base href="/ui/">
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />

--- a/src/app.rs
+++ b/src/app.rs
@@ -168,7 +168,7 @@ impl<Ms, Mdl, INodes: IntoNodes<Ms> + 'static, GMs: 'static> App<Ms, Mdl, INodes
                 .and_then(|href| web_sys::Url::new_with_base(&href, DUMMY_BASE_URL).ok())
                 .map(|url| {
                     url.pathname()
-                        .trim_start_matches('/')
+                        .trim_matches('/')
                         .split('/')
                         .map(ToOwned::to_owned)
                         .collect()

--- a/src/app/orders.rs
+++ b/src/app/orders.rs
@@ -277,7 +277,7 @@ pub trait Orders<Ms: 'static, GMs = UndefinedGMsg> {
         stream: impl Stream<Item = MsU> + 'static,
     ) -> StreamHandle;
 
-    /// Cheap clone base path loaded from element `<base href="base/path">`.
+    /// Cheap clone base path loaded from element `<base href="/base/path/">`.
     ///
     /// Returns empty `Vec` if there is no `base` element in your HTML
     /// or there were problems with parsing.


### PR DESCRIPTION
`<base href="/base/path/">` - there should be a trailing slash because browsers can't route static files properly without it. However Seed didn't expect the trailing slash and it was breaking base path handling.