### PR TITLE
fix: C macro memory issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## [unreleased]
-- [BREAKING] Rename `linear_gradient!` to `linearGradient!` for consistency with the other svg macros (same with `radial_gradient!` and `mesh_gradient!`).
+- [BREAKING] Rename `linear_gradient!` to `linearGradient!` for consistency with the other svg macros (same with `radial_gradient!` and `mesh_gradient!`) (#377).
 - Fixed `base_path` with a trailing slash parsing / handling.
+- Fixed `C` macro memory / WASM file size issue.
 
 ## v0.7.0
 - [BREAKING] Custom elements are now patched in-place (#364). Use `el_key` to force reinitialize an element.

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -3,6 +3,7 @@
 
 // @TODO merge with `pub use` & `prelude` in `lib.rs` and `browser::util`?
 
+use crate::virtual_dom::{At, Attrs};
 use wasm_bindgen::JsValue;
 
 /// Copied from [https://github.com/rust-lang/rust/issues/35853](https://github.com/rust-lang/rust/issues/35853)
@@ -325,22 +326,32 @@ macro_rules! C {
         {
             let mut all_classes = Vec::new();
             $(
-                if let Some(classes) = $class.to_classes() {
-                    for class in classes {
-                        if !class.is_empty() {
-                            all_classes.push(class);
-                        }
-                    }
-                }
+                $crate::shortcuts::_fill_all_classes(&mut all_classes, $class.to_classes());
             )*
-
-            let mut attrs = $crate::virtual_dom::Attrs::empty();
-            if !all_classes.is_empty() {
-                attrs.add_multiple(At::Class, &all_classes.iter().map(|class| class.as_str()).collect::<Vec<_>>());
-            }
-            attrs
+            $crate::shortcuts::_all_classes_to_attrs(&all_classes)
         }
     };
+}
+
+pub fn _fill_all_classes(all_classes: &mut Vec<String>, classes: Option<Vec<String>>) {
+    if let Some(classes) = classes {
+        for class in classes {
+            if !class.is_empty() {
+                all_classes.push(class);
+            }
+        }
+    }
+}
+
+pub fn _all_classes_to_attrs(all_classes: &[String]) -> Attrs {
+    let mut attrs = Attrs::empty();
+    if !all_classes.is_empty() {
+        attrs.add_multiple(
+            At::Class,
+            &all_classes.iter().map(String::as_str).collect::<Vec<_>>(),
+        );
+    }
+    attrs
 }
 
 /// `IF!(predicate => expression) -> Option<expression value>`


### PR DESCRIPTION
When the app in [quickstart-webpack](https://github.com/seed-rs/seed-quickstart-webpack) uses Seed 0.7.0 and `C!` (instead of `class!`), then the WASM file size (in debug mode) has 7.58 MB and fails during the start with `CompileError: wasm validation error: at offset 26669: too many locals` (build is also pretty slow). 

Both new helper functions introduced in the PR - `_fill_all_classes` and `_all_classes_to_attrs` - reduce the WASM size by +/-2 MB so with this PR the result size is 3.15 MB.

I've resolved this issue by intuition, but I don't really know why this happens, how to prevent it and if we can define a general rule - e.g. "macros should be as small as possible".

Opinions? (cc @rebo, @akhilman, @flosse, @TatriX)