### PR TITLE
doc(README): expand on pages_keep_state example description

### DIFF
--- a/examples/pages_keep_state/README.md
+++ b/examples/pages_keep_state/README.md
@@ -1,7 +1,20 @@
 ## Pages-keep-state example
 
-How to create and browse multiple pages in your app.
-Lazy load pages and keep their state.
+How to create and browse multiple pages in your app, demonstrating lazy loading model values and persisting selected page state across page loads.
+
+The pattern used in this example is probably better suited to more complex websites or apps where you want to keep model state across page loads, e.g. where there are many filters configurable by the user or there are time-consuming init operations such as multiple fetches.
+
+In this example the current page is stored in [Model.page_id](https://github.com/seed-rs/seed/blob/master/examples/pages_keep_state/src/lib.rs#L36-L37) and `Model.admin_model` represents the admin report subpage selected by the user.
+
+Lazy model initialization is used and the report subpage selection persists until changed by the user.
+
+To see this in action, follow these steps:
+
+1. Open the example and select `report`. Notice the page text "This is your _daily_ report".
+2. Select `Switch to weekly`. Notice the page text "This is your _weekly_ report".
+3. Select `Home` then `Report`. The report page persists at "This is your _weekly_ report".
+
+The `pages` example pattern is simpler and maybe more predictable, without lazy model loading or page state persistence.
 
 ---
 


### PR DESCRIPTION
Expanded README to more fully explain the purpose and function of the pages_keep_state example.