### PR TITLE
doc(README): expand on pages example description

### DIFF
--- a/examples/pages/README.md
+++ b/examples/pages/README.md
@@ -2,6 +2,12 @@
 
 How to create and browse multiple pages in your app.
 
+A simple and predictable page navigation example pattern.
+
+In this example the current page is a value from the `Page` enum and is stored in [Model.page](https://github.com/seed-rs/seed/blob/master/examples/pages/src/lib.rs#L31)
+
+The `pages_keep_state` example is probably better suited to more complex websites or apps where you want to keep Model state across page loads.
+
 ---
 
 ```bash


### PR DESCRIPTION
Expanded README to more fully explain the purpose and function of the pages example.