### PR TITLE
Replace `Blob::array_buffer` with `FileReader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [BREAKING] Renamed module `effects` to `effect`.
 - Added `App::update_with_option`.
 - Added `Navigator` and `BeforeUnloadEvent` into Seed's `web_sys`.
+- Fixed runtime exception when using binary data in WS on some browsers. (#470)
 
 ## v0.7.0
 - [BREAKING] Custom elements are now patched in-place (#364). Use `el_key` to force reinitialize an element.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ features = [
     "Event",
     "EventTarget",
     "File",
+    "FileReader",
     "FormData",
     "HashChangeEvent",
     "Headers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ features = [
     "Event",
     "EventTarget",
     "File",
-    "FileReader",
     "FormData",
     "HashChangeEvent",
     "Headers",

--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -14,8 +14,9 @@ path = "src/server.rs"
 
 [dependencies]
 # common
-serde = { version = "1.0.106", features = ["derive"] }
-serde_json = "1.0.52"
+serde = { version = "1.0.110", features = ["derive"] }
+serde_json = "1.0.53"
+rmp-serde = "0.14"
 
 # server
 ws = { version = "0.9.1", optional = true }

--- a/src/browser/web_socket.rs
+++ b/src/browser/web_socket.rs
@@ -51,7 +51,7 @@ pub enum WebSocketError {
     SendError(JsValue),
     SerdeError(serde_json::Error),
     PromiseError(JsValue),
-    FileRedaerError(FileReadError),
+    FileReaderError(FileReadError),
     OpenError(JsValue),
     CloseError(JsValue),
 }

--- a/src/browser/web_socket.rs
+++ b/src/browser/web_socket.rs
@@ -1,4 +1,5 @@
 use crate::app::Orders;
+use gloo_file::FileReadError;
 use serde::Serialize;
 use wasm_bindgen::{JsCast, JsValue};
 
@@ -50,6 +51,7 @@ pub enum WebSocketError {
     SendError(JsValue),
     SerdeError(serde_json::Error),
     PromiseError(JsValue),
+    FileRedaerError(FileReadError),
     OpenError(JsValue),
     CloseError(JsValue),
 }

--- a/src/browser/web_socket/message.rs
+++ b/src/browser/web_socket/message.rs
@@ -51,7 +51,7 @@ impl WebSocketMessage {
             let blob = gloo_file::Blob::from(blob.to_owned());
             let bytes = gloo_file::futures::read_as_bytes(&blob)
                 .await
-                .map_err(WebSocketError::FileRedaerError)?;
+                .map_err(WebSocketError::FileReaderError)?;
             return Ok(bytes);
         }
 
@@ -110,5 +110,25 @@ impl WebSocketMessage {
     /// [issue]: https://github.com/seed-rs/seed/issues
     pub const fn raw_message(&self) -> &web_sys::MessageEvent {
         &self.message_event
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::browser::web_socket::WebSocketMessage;
+    use wasm_bindgen_test::*;
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    async fn get_bytes_from_message() {
+        let bytes = "some test message".as_bytes();
+        let blob = gloo_file::Blob::new(bytes);
+        let message_event = web_sys::MessageEvent::new("test").unwrap();
+        let ws_msg = WebSocketMessage {
+            data: blob.into(),
+            message_event,
+        };
+        let result_bytes = ws_msg.bytes().await.unwrap();
+        assert_eq!(bytes, &*result_bytes);
     }
 }

--- a/src/browser/web_socket/message.rs
+++ b/src/browser/web_socket/message.rs
@@ -51,7 +51,7 @@ impl WebSocketMessage {
         }
 
         if let Some(blob) = self.data.dyn_ref::<web_sys::Blob>() {
-            let bytes = JsFuture::from(self.handle_blob(&blob))
+            let bytes = JsFuture::from(WebSocketMessage::handle_blob(blob))
                 .await
                 .map_err(WebSocketError::PromiseError)
                 .map(|array_buffer| js_sys::Uint8Array::new(&array_buffer))?
@@ -66,10 +66,10 @@ impl WebSocketMessage {
     // Unfortunatelly `web_sys::Blob::array_buffer()` is not supported by many browsers including
     // Internet Explorer, Opera and Safari.
     // Full compatibility list: https://developer.mozilla.org/en-US/docs/Web/API/Blob/arrayBuffer
-    fn handle_blob(&self, blob: &web_sys::Blob) -> Promise {
-        let mut callback = Box::new(|resolve: Function, _: Function| -> () {
+    fn handle_blob(blob: &web_sys::Blob) -> Promise {
+        let mut callback = Box::new(|resolve: Function, _: Function| {
             let file_reader = FileReader::new().unwrap();
-            file_reader.read_as_array_buffer(&blob).unwrap();
+            file_reader.read_as_array_buffer(blob).unwrap();
 
             let onload = Closure::wrap(Box::new(move |event: Event| {
                 let file_reader: FileReader = event.target().unwrap().dyn_into().unwrap();


### PR DESCRIPTION
This PR replaces the `Blob:array_buffer` usage with the FileReader. This change fixes #470.

This is my first PR to seed, and the first time that I had anything to do with wasm_bindgen so I would really appreciate a review.