### PR TITLE
Url API changes

### DIFF
--- a/examples/auth/src/lib.rs
+++ b/examples/auth/src/lib.rs
@@ -18,7 +18,7 @@ fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
     Model {
         email: "john@example.com".to_owned(),
         password: "1234".to_owned(),
-        base_url: url.to_base_url(),
+        base_url: url.clone().truncate_relative_path(),
         page: Page::init(url, user.as_ref(), orders),
         secret_message: None,
         user,
@@ -59,7 +59,7 @@ enum Page {
 
 impl Page {
     fn init(mut url: Url, user: Option<&LoggedUser>, orders: &mut impl Orders<Msg>) -> Self {
-        match url.next_path_part() {
+        match url.pop_relative_path_part() {
             None => {
                 if let Some(user) = user {
                     send_request_to_top_secret(user.token.clone(), orders)
@@ -99,7 +99,7 @@ impl<'a> Urls<'a> {
         self.base_url()
     }
     pub fn login(self) -> Url {
-        self.base_url().add_path_part(LOGIN)
+        self.base_url().push_path_part(LOGIN)
     }
 }
 

--- a/examples/pages/src/lib.rs
+++ b/examples/pages/src/lib.rs
@@ -16,7 +16,7 @@ fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
         ctx: Context {
             logged_user: "John Doe",
         },
-        base_url: url.to_base_url(),
+        base_url: url.clone().truncate_relative_path(),
         page: Page::init(url),
     }
 }
@@ -47,7 +47,7 @@ enum Page {
 
 impl Page {
     fn init(mut url: Url) -> Self {
-        match url.next_path_part() {
+        match url.pop_relative_path_part() {
             None => Self::Home,
             Some(ADMIN) => page::admin::init(url).map_or(Self::NotFound, Self::Admin),
             _ => Self::NotFound,
@@ -65,7 +65,7 @@ impl<'a> Urls<'a> {
         self.base_url()
     }
     pub fn admin_urls(self) -> page::admin::Urls<'a> {
-        page::admin::Urls::new(self.base_url().add_path_part(ADMIN))
+        page::admin::Urls::new(self.base_url().push_path_part(ADMIN))
     }
 }
 

--- a/examples/pages/src/page/admin.rs
+++ b/examples/pages/src/page/admin.rs
@@ -11,7 +11,7 @@ mod page;
 
 pub fn init(mut url: Url) -> Option<Model> {
     Some(Model {
-        report_page: match url.next_path_part() {
+        report_page: match url.pop_relative_path_part() {
             Some(REPORT) => page::report::init(url)?,
             _ => None?,
         },
@@ -33,7 +33,7 @@ pub struct Model {
 struct_urls!();
 impl<'a> Urls<'a> {
     pub fn report_urls(self) -> page::report::Urls<'a> {
-        page::report::Urls::new(self.base_url().add_path_part(REPORT))
+        page::report::Urls::new(self.base_url().push_path_part(REPORT))
     }
 }
 

--- a/examples/pages/src/page/admin/page/report.rs
+++ b/examples/pages/src/page/admin/page/report.rs
@@ -9,9 +9,9 @@ const WEEKLY: &str = "weekly";
 // ------ ------
 
 pub fn init(mut url: Url) -> Option<Model> {
-    let base_url = url.to_base_url();
+    let base_url = url.clone().truncate_relative_path();
 
-    let frequency = match url.remaining_path_parts().as_slice() {
+    let frequency = match url.consume_relative_path().as_slice() {
         [] => {
             Urls::new(&base_url).default().go_and_replace();
             Frequency::default()
@@ -59,10 +59,10 @@ impl<'a> Urls<'a> {
         self.daily()
     }
     pub fn daily(self) -> Url {
-        self.base_url().add_path_part(DAILY)
+        self.base_url().push_path_part(DAILY)
     }
     pub fn weekly(self) -> Url {
-        self.base_url().add_path_part(WEEKLY)
+        self.base_url().push_path_part(WEEKLY)
     }
 }
 

--- a/examples/pages_hash_routing/src/lib.rs
+++ b/examples/pages_hash_routing/src/lib.rs
@@ -16,7 +16,7 @@ fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
         ctx: Context {
             logged_user: "John Doe",
         },
-        base_url: url.to_hash_base_url(),
+        base_url: url.clone().truncate_relative_hash_path(),
         page: Page::init(url),
     }
 }
@@ -47,7 +47,7 @@ enum Page {
 
 impl Page {
     fn init(mut url: Url) -> Self {
-        match url.next_hash_path_part() {
+        match url.pop_relative_hash_path_part() {
             None => Self::Home,
             Some(ADMIN) => page::admin::init(url).map_or(Self::NotFound, Self::Admin),
             _ => Self::NotFound,
@@ -65,7 +65,7 @@ impl<'a> Urls<'a> {
         self.base_url()
     }
     pub fn admin_urls(self) -> page::admin::Urls<'a> {
-        page::admin::Urls::new(self.base_url().add_hash_path_part(ADMIN))
+        page::admin::Urls::new(self.base_url().push_hash_path_part(ADMIN))
     }
 }
 

--- a/examples/pages_hash_routing/src/page/admin.rs
+++ b/examples/pages_hash_routing/src/page/admin.rs
@@ -11,7 +11,7 @@ mod page;
 
 pub fn init(mut url: Url) -> Option<Model> {
     Some(Model {
-        report_page: match url.next_hash_path_part() {
+        report_page: match url.pop_relative_hash_path_part() {
             Some(REPORT) => page::report::init(url)?,
             _ => None?,
         },
@@ -33,7 +33,7 @@ pub struct Model {
 struct_urls!();
 impl<'a> Urls<'a> {
     pub fn report_urls(self) -> page::report::Urls<'a> {
-        page::report::Urls::new(self.base_url().add_hash_path_part(REPORT))
+        page::report::Urls::new(self.base_url().push_hash_path_part(REPORT))
     }
 }
 

--- a/examples/pages_hash_routing/src/page/admin/page/report.rs
+++ b/examples/pages_hash_routing/src/page/admin/page/report.rs
@@ -9,9 +9,9 @@ const WEEKLY: &str = "weekly";
 // ------ ------
 
 pub fn init(mut url: Url) -> Option<Model> {
-    let base_url = url.to_hash_base_url();
+    let base_url = url.clone().truncate_relative_hash_path();
 
-    let frequency = match url.remaining_hash_path_parts().as_slice() {
+    let frequency = match url.consume_relative_hash_path().as_slice() {
         [] => {
             Urls::new(&base_url).default().go_and_replace();
             Frequency::default()
@@ -59,10 +59,10 @@ impl<'a> Urls<'a> {
         self.daily()
     }
     pub fn daily(self) -> Url {
-        self.base_url().add_hash_path_part(DAILY)
+        self.base_url().push_hash_path_part(DAILY)
     }
     pub fn weekly(self) -> Url {
-        self.base_url().add_hash_path_part(WEEKLY)
+        self.base_url().push_hash_path_part(WEEKLY)
     }
 }
 

--- a/examples/pages_keep_state/src/lib.rs
+++ b/examples/pages_keep_state/src/lib.rs
@@ -11,16 +11,15 @@ const ADMIN: &str = "admin";
 // ------ ------
 
 fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
-    let base_url = url.clone().truncate_relative_path();
     orders
         .subscribe(Msg::UrlChanged)
-        .notify(subs::UrlChanged(url));
+        .notify(subs::UrlChanged(url.clone()));
 
     Model {
         ctx: Context {
             logged_user: "John Doe",
         },
-        base_url,
+        base_url: url.truncate_relative_path(),
         page_id: None,
         admin_model: None,
     }

--- a/examples/pages_keep_state/src/lib.rs
+++ b/examples/pages_keep_state/src/lib.rs
@@ -11,7 +11,7 @@ const ADMIN: &str = "admin";
 // ------ ------
 
 fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
-    let base_url = url.to_base_url();
+    let base_url = url.clone().truncate_relative_path();
     orders
         .subscribe(Msg::UrlChanged)
         .notify(subs::UrlChanged(url));
@@ -61,7 +61,7 @@ impl<'a> Urls<'a> {
         self.base_url()
     }
     pub fn admin_urls(self) -> page::admin::Urls<'a> {
-        page::admin::Urls::new(self.base_url().add_path_part(ADMIN))
+        page::admin::Urls::new(self.base_url().push_path_part(ADMIN))
     }
 }
 
@@ -76,7 +76,7 @@ enum Msg {
 fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
     match msg {
         Msg::UrlChanged(subs::UrlChanged(mut url)) => {
-            model.page_id = match url.next_path_part() {
+            model.page_id = match url.pop_relative_path_part() {
                 None => Some(PageId::Home),
                 Some(ADMIN) => {
                     page::admin::init(url, &mut model.admin_model).map(|_| PageId::Admin)

--- a/examples/pages_keep_state/src/page/admin.rs
+++ b/examples/pages_keep_state/src/page/admin.rs
@@ -11,7 +11,7 @@ mod page;
 
 pub fn init(mut url: Url, model: &mut Option<Model>) -> Option<()> {
     let model = model.get_or_insert_with(Model::default);
-    model.page_id.replace(match url.next_path_part() {
+    model.page_id.replace(match url.pop_relative_path_part() {
         Some(REPORT) => page::report::init(url, &mut model.report_model).map(|_| PageId::Report)?,
         _ => None?,
     });
@@ -42,7 +42,7 @@ enum PageId {
 struct_urls!();
 impl<'a> Urls<'a> {
     pub fn report_urls(self) -> page::report::Urls<'a> {
-        page::report::Urls::new(self.base_url().add_path_part(REPORT))
+        page::report::Urls::new(self.base_url().push_path_part(REPORT))
     }
 }
 

--- a/examples/pages_keep_state/src/page/admin/page/report.rs
+++ b/examples/pages_keep_state/src/page/admin/page/report.rs
@@ -10,11 +10,11 @@ const WEEKLY: &str = "weekly";
 
 pub fn init(mut url: Url, model: &mut Option<Model>) -> Option<()> {
     let model = model.get_or_insert_with(|| Model {
-        base_url: url.to_base_url(),
+        base_url: url.clone().truncate_relative_path(),
         frequency: Frequency::Daily,
     });
 
-    model.frequency = match url.remaining_path_parts().as_slice() {
+    model.frequency = match url.consume_relative_path().as_slice() {
         [] => {
             match model.frequency {
                 Frequency::Daily => Urls::new(&model.base_url).daily().go_and_replace(),
@@ -56,10 +56,10 @@ impl<'a> Urls<'a> {
         self.base_url()
     }
     pub fn daily(self) -> Url {
-        self.base_url().add_path_part(DAILY)
+        self.base_url().push_path_part(DAILY)
     }
     pub fn weekly(self) -> Url {
-        self.base_url().add_path_part(WEEKLY)
+        self.base_url().push_path_part(WEEKLY)
     }
 }
 

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -117,7 +117,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     let data = &mut model.data;
     match msg {
         Msg::UrlChanged(subs::UrlChanged(mut url)) => {
-            data.filter = match url.next_path_part() {
+            data.filter = match url.pop_relative_path_part() {
                 Some(path_part) if path_part == TodoFilter::Active.to_url_path() => {
                     TodoFilter::Active
                 }

--- a/examples/unsaved_changes/src/lib.rs
+++ b/examples/unsaved_changes/src/lib.rs
@@ -18,7 +18,7 @@ fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
 
     let text = LocalStorage::get(STORAGE_KEY).unwrap_or_default();
     Model {
-        base_url: url.to_base_url(),
+        base_url: url.clone().truncate_relative_path(),
         saved_text_hash: calculate_hash(&text),
         text,
     }
@@ -44,7 +44,7 @@ impl<'a> Urls<'a> {
         self.base_url()
     }
     fn no_home(self) -> Url {
-        self.base_url().add_path_part("no-home")
+        self.base_url().push_path_part("no-home")
     }
 }
 

--- a/examples/url/src/lib.rs
+++ b/examples/url/src/lib.rs
@@ -77,7 +77,7 @@ fn view(model: &Model) -> Node<Msg> {
                         .set_path(&["ui", "a", "b", "c"])
                         .set_search(vec![
                             ("x", vec!["1"])
-                        ].iter().collect())
+                        ].into_iter().collect())
                         .set_hash("hash")
                         .go_and_load()
                 })

--- a/examples/url/src/lib.rs
+++ b/examples/url/src/lib.rs
@@ -75,9 +75,9 @@ fn view(model: &Model) -> Node<Msg> {
                 ev(Ev::Click, |_| {
                     Url::new()
                         .set_path(&["ui", "a", "b", "c"])
-                        .set_search(UrlSearch::new(vec![
+                        .set_search(vec![
                             ("x", vec!["1"])
-                        ]))
+                        ].iter().collect())
                         .set_hash("hash")
                         .go_and_load()
                 })

--- a/examples/url/src/lib.rs
+++ b/examples/url/src/lib.rs
@@ -32,10 +32,10 @@ impl Model {
         Self {
             base_path,
             initial_url: url.clone(),
-            base_url: url.to_base_url(),
-            next_path_part: url.next_path_part().map(ToOwned::to_owned),
+            base_url: url.clone().truncate_relative_path(),
+            next_path_part: url.pop_relative_path_part().map(ToOwned::to_owned),
             remaining_path_parts: url
-                .remaining_path_parts()
+                .consume_relative_path()
                 .into_iter()
                 .map(ToOwned::to_owned)
                 .collect(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -184,7 +184,7 @@ impl<Ms, Mdl, INodes: IntoNodes<Ms> + 'static, GMs: 'static> App<Ms, Mdl, INodes
                 move |url: Url,
                       orders: &mut OrdersContainer<Ms, Mdl, INodes, GMs>|
                       -> AfterMount<Mdl> {
-                    let url = url.skip_base_path(&base_path);
+                    let url = url.try_skip_base_path(&base_path);
                     let model = init(url, orders);
                     AfterMount::new(model).url_handling(UrlHandling::None)
                 }

--- a/src/browser/service/routing.rs
+++ b/src/browser/service/routing.rs
@@ -46,7 +46,7 @@ pub fn setup_popstate_listener<Ms>(
         };
 
         notify(Notification::new(subs::UrlChanged(
-            url.clone().skip_base_path(&base_path),
+            url.clone().try_skip_base_path(&base_path),
         )));
 
         if let Some(routes) = routes {
@@ -85,7 +85,7 @@ pub fn setup_hashchange_listener<Ms>(
             .expect("cast hashchange event url to `Url`");
 
         notify(Notification::new(subs::UrlChanged(
-            url.clone().skip_base_path(&base_path),
+            url.clone().try_skip_base_path(&base_path),
         )));
 
         if let Some(routes) = routes {
@@ -117,7 +117,7 @@ pub(crate) fn url_request_handler(
                 event.prevent_default(); // Prevent page refresh
             }
             notify(Notification::new(subs::UrlChanged(
-                url.skip_base_path(&base_path),
+                url.try_skip_base_path(&base_path),
             )));
         }
         subs::url_requested::UrlRequestStatus::Handled(prevent_default) => {

--- a/src/browser/url.rs
+++ b/src/browser/url.rs
@@ -664,12 +664,13 @@ mod tests {
         let expected = "/Hello%20G%C3%BCnter/path2?calc=5%2B6&x=1&x=2#he%C5%A1";
         let native_url = web_sys::Url::new_with_base(expected, DUMMY_BASE_URL).unwrap();
         let url = Url::from(&native_url);
+        let expected_search: UrlSearch = vec![("calc", vec!["5+6"]), ("x", vec!["1", "2"]),].into_iter().collect();
 
         assert_eq!(url.path()[0], "Hello Günter");
         assert_eq!(url.path()[1], "path2");
         assert_eq!(
             url.search(),
-            &UrlSearch::new(vec![("calc", vec!["5+6"]), ("x", vec!["1", "2"]),])
+            &expected_search,
         );
         assert_eq!(url.hash(), Some(&"heš".to_owned()));
 
@@ -688,7 +689,7 @@ mod tests {
     fn parse_url_with_hash_search() {
         let expected = Url::new()
             .set_path(&["path"])
-            .set_search(UrlSearch::new(vec![("search", vec!["query"])]))
+            .set_search(vec![("search", vec!["query"])].into_iter().collect())
             .set_hash("hash");
         let actual: Url = "/path?search=query#hash".parse().unwrap();
         assert_eq!(expected, actual)
@@ -714,7 +715,7 @@ mod tests {
 
         let actual = Url::new()
             .set_path(&["foo", "bar"])
-            .set_search(UrlSearch::new(vec![("q", vec!["42"]), ("z", vec!["13"])]))
+            .set_search(vec![("q", vec!["42"]), ("z", vec!["13"])].into_iter().collect())
             .set_hash_path(&["discover"])
             .to_string();
 

--- a/src/browser/url.rs
+++ b/src/browser/url.rs
@@ -447,14 +447,14 @@ impl Url {
     ///                  ^-----base-----^
     ///                  ^---absolute---^
     /// ```
-    pub fn truncate_relative_path(&mut self) -> &mut Self {
+    pub fn truncate_relative_path(mut self) -> Self {
         self.path.truncate(self.base_path_len);
         self
     }
 
     /// Clone the `Url` and strip relative hash path. Similar to
     /// `truncate_relative_path`.
-    pub fn truncate_relative_hash_path(&mut self) -> &mut Self {
+    pub fn truncate_relative_hash_path(mut self) -> Self {
         self.hash_path.truncate(self.base_hash_path_len);
         self
     }

--- a/src/browser/url.rs
+++ b/src/browser/url.rs
@@ -204,7 +204,7 @@ impl Url {
     ///
     /// # Refenences
     /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/URL/search)
-    pub fn set_search(mut self, search: impl Into<UrlSearch>) -> Self {
+    pub fn set_search(mut self, search: UrlSearch) -> Self {
         self.search = search.into();
         self
     }

--- a/src/browser/url.rs
+++ b/src/browser/url.rs
@@ -1,7 +1,10 @@
 use crate::browser::util;
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, collections::BTreeMap, fmt, str::FromStr};
+use std::{borrow::Cow, fmt, str::FromStr};
 use wasm_bindgen::JsValue;
+
+mod search;
+pub use search::UrlSearch;
 
 pub const DUMMY_BASE_URL: &str = "http://example.com";
 
@@ -548,161 +551,6 @@ impl From<&web_sys::Url> for Url {
             search,
             invalid_components,
         }
-    }
-}
-
-// ------ UrlSearch ------
-
-#[allow(clippy::module_name_repetitions)]
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct UrlSearch {
-    search: BTreeMap<String, Vec<String>>,
-    invalid_components: Vec<String>,
-}
-
-impl UrlSearch {
-    /// Makes a new `UrlSearch` with the provided parameters.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,no_run
-    /// UrlSearch::new(vec![
-    ///     ("sort", vec!["date", "name"]),
-    ///     ("category", vec!["top"])
-    /// ])
-    /// ```
-    pub fn new<K, V, VS>(params: impl IntoIterator<Item = (K, VS)>) -> Self
-    where
-        K: Into<String>,
-        V: Into<String>,
-        VS: IntoIterator<Item = V>,
-    {
-        let mut search = BTreeMap::new();
-        for (key, values) in params {
-            search.insert(key.into(), values.into_iter().map(Into::into).collect());
-        }
-        Self {
-            search,
-            invalid_components: Vec::new(),
-        }
-    }
-
-    /// Returns `true` if the `UrlSearch` contains a value for the specified key.
-    pub fn contains_key(&self, key: impl AsRef<str>) -> bool {
-        self.search.contains_key(key.as_ref())
-    }
-
-    /// Returns a reference to values corresponding to the key.
-    pub fn get(&self, key: impl AsRef<str>) -> Option<&Vec<String>> {
-        self.search.get(key.as_ref())
-    }
-
-    /// Returns a mutable reference to values corresponding to the key.
-    pub fn get_mut(&mut self, key: impl AsRef<str>) -> Option<&mut Vec<String>> {
-        self.search.get_mut(key.as_ref())
-    }
-
-    /// Push the value into the vector of values corresponding to the key.
-    /// - If the key and values are not present, they will be crated.
-    pub fn push_value<'a>(&mut self, key: impl Into<Cow<'a, str>>, value: String) {
-        let key = key.into();
-        if self.search.contains_key(key.as_ref()) {
-            self.search.get_mut(key.as_ref()).unwrap().push(value);
-        } else {
-            self.search.insert(key.into_owned(), vec![value]);
-        }
-    }
-
-    /// Inserts a key-values pair into the `UrlSearch`.
-    /// - If the `UrlSearch` did not have this key present, `None` is returned.
-    /// - If the `UrlSearch` did have this key present, old values are overwritten by new ones,
-    /// and old values are returned. The key is not updated.
-    pub fn insert(&mut self, key: String, values: Vec<String>) -> Option<Vec<String>> {
-        self.search.insert(key, values)
-    }
-
-    /// Removes a key from the `UrlSearch`, returning values at the key
-    /// if the key was previously in the `UrlSearch`.
-    pub fn remove(&mut self, key: impl AsRef<str>) -> Option<Vec<String>> {
-        self.search.remove(key.as_ref())
-    }
-
-    /// Gets an iterator over the entries of the `UrlSearch`, sorted by key.
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &Vec<String>)> {
-        self.search.iter()
-    }
-
-    /// Get invalid components.
-    ///
-    /// Undecodable / unparsable components are invalid.
-    pub fn invalid_components(&self) -> &[String] {
-        &self.invalid_components
-    }
-
-    /// Get mutable invalid components.
-    ///
-    /// Undecodable / unparsable components are invalid.
-    pub fn invalid_components_mut(&mut self) -> &mut Vec<String> {
-        &mut self.invalid_components
-    }
-}
-
-/// `UrlSearch` components are automatically encoded.
-impl fmt::Display for UrlSearch {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let params = web_sys::UrlSearchParams::new().expect("create a new UrlSearchParams");
-
-        for (key, values) in &self.search {
-            for value in values {
-                params.append(key, value);
-            }
-        }
-        write!(fmt, "{}", String::from(params.to_string()))
-    }
-}
-
-impl From<web_sys::UrlSearchParams> for UrlSearch {
-    /// Creates a new `UrlSearch` from the browser native `UrlSearchParams`.
-    /// `UrlSearch`'s components are decoded if possible. When decoding fails, the component is cloned
-    /// into `invalid_components` and the original value is used.
-    fn from(params: web_sys::UrlSearchParams) -> Self {
-        let mut url_search = Self::default();
-        let mut invalid_components = Vec::<String>::new();
-
-        for param in js_sys::Array::from(&params).to_vec() {
-            let key_value_pair = js_sys::Array::from(&param).to_vec();
-
-            let key = key_value_pair
-                .get(0)
-                .expect("get UrlSearchParams key from key-value pair")
-                .as_string()
-                .expect("cast UrlSearchParams key to String");
-            let value = key_value_pair
-                .get(1)
-                .expect("get UrlSearchParams value from key-value pair")
-                .as_string()
-                .expect("cast UrlSearchParams value to String");
-
-            let key = match Url::decode_uri_component(&key) {
-                Ok(decoded_key) => decoded_key,
-                Err(_) => {
-                    invalid_components.push(key.clone());
-                    key
-                }
-            };
-            let value = match Url::decode_uri_component(&value) {
-                Ok(decoded_value) => decoded_value,
-                Err(_) => {
-                    invalid_components.push(value.clone());
-                    value
-                }
-            };
-
-            url_search.push_value(key, value)
-        }
-
-        url_search.invalid_components = invalid_components;
-        url_search
     }
 }
 

--- a/src/browser/url.rs
+++ b/src/browser/url.rs
@@ -66,7 +66,7 @@ impl Url {
     pub fn path(&self) -> &[String] {
         &self.path
     }
-    
+
     /// Get the base path.
     pub fn base_path(&mut self) -> &[String] {
         &self.path[0..self.base_path_len]
@@ -247,7 +247,7 @@ impl Url {
             .replace_state_with_url(&data, "", Some(&self.to_string()))
             .expect("Problem pushing state");
     }
-    
+
     /// Change the browser URL and trigger a page load.
     pub fn go_and_load(&self) {
         Self::go_and_load_with_str(self.to_string())
@@ -314,9 +314,9 @@ impl Url {
     ///                  ^base^ ^----relative------^
     ///                  ^---------absolute--------^
     /// ```
-    /// 
+    ///
     /// and after:
-    /// 
+    ///
     /// ```text
     /// https://site.com/albums/seedlings/oak-45.png
     ///                  ^-----base-----^ ^relative^
@@ -370,9 +370,9 @@ impl Url {
     ///                  ^base^ ^----relative------^
     ///                  ^---------absolute--------^
     /// ```
-    /// 
+    ///
     /// and after:
-    /// 
+    ///
     /// ```text
     /// https://site.com/albums/seedlings/oak-45.png
     ///                  ^-----------base----------^
@@ -439,9 +439,9 @@ impl Url {
     ///                  ^-----base-----^ ^relative^
     ///                  ^---------absolute--------^
     /// ```
-    /// 
+    ///
     /// and output:
-    /// 
+    ///
     /// ```text
     /// https://site.com/albums/seedlings
     ///                  ^-----base-----^
@@ -584,13 +584,11 @@ impl From<&web_sys::Url> for Url {
             let path = url.pathname();
             path.split('/')
                 .filter(|path_part| !path_part.is_empty())
-                .map(|path_part| {
-                    match Url::decode_uri_component(path_part) {
-                        Ok(decoded_path_part) => decoded_path_part,
-                        Err(_) => {
-                            invalid_components.push(path_part.to_owned());
-                            path_part.to_string()
-                        }
+                .map(|path_part| match Url::decode_uri_component(path_part) {
+                    Ok(decoded_path_part) => decoded_path_part,
+                    Err(_) => {
+                        invalid_components.push(path_part.to_owned());
+                        path_part.to_string()
                     }
                 })
                 .collect()
@@ -605,15 +603,14 @@ impl From<&web_sys::Url> for Url {
                 let hash = &hash['#'.len_utf8()..];
 
                 // Decode hash path parts.
-                let hash_path = hash.split('/')
+                let hash_path = hash
+                    .split('/')
                     .filter(|path_part| !path_part.is_empty())
-                    .map(|path_part| {
-                        match Url::decode_uri_component(path_part) {
-                            Ok(decoded_path_part) => decoded_path_part,
-                            Err(_) => {
-                                invalid_components.push(path_part.to_owned());
-                                path_part.to_owned()
-                            }
+                    .map(|path_part| match Url::decode_uri_component(path_part) {
+                        Ok(decoded_path_part) => decoded_path_part,
+                        Err(_) => {
+                            invalid_components.push(path_part.to_owned());
+                            path_part.to_owned()
                         }
                     })
                     .collect();
@@ -664,14 +661,13 @@ mod tests {
         let expected = "/Hello%20G%C3%BCnter/path2?calc=5%2B6&x=1&x=2#he%C5%A1";
         let native_url = web_sys::Url::new_with_base(expected, DUMMY_BASE_URL).unwrap();
         let url = Url::from(&native_url);
-        let expected_search: UrlSearch = vec![("calc", vec!["5+6"]), ("x", vec!["1", "2"]),].into_iter().collect();
+        let expected_search: UrlSearch = vec![("calc", vec!["5+6"]), ("x", vec!["1", "2"])]
+            .into_iter()
+            .collect();
 
         assert_eq!(url.path()[0], "Hello Günter");
         assert_eq!(url.path()[1], "path2");
-        assert_eq!(
-            url.search(),
-            &expected_search,
-        );
+        assert_eq!(url.search(), &expected_search,);
         assert_eq!(url.hash(), Some(&"heš".to_owned()));
 
         let actual = url.to_string();
@@ -715,7 +711,11 @@ mod tests {
 
         let actual = Url::new()
             .set_path(&["foo", "bar"])
-            .set_search(vec![("q", vec!["42"]), ("z", vec!["13"])].into_iter().collect())
+            .set_search(
+                vec![("q", vec!["42"]), ("z", vec!["13"])]
+                    .into_iter()
+                    .collect(),
+            )
             .set_hash_path(&["discover"])
             .to_string();
 

--- a/src/browser/url.rs
+++ b/src/browser/url.rs
@@ -66,6 +66,16 @@ impl Url {
     pub fn path(&self) -> &[String] {
         &self.path
     }
+    
+    /// Get the base path.
+    pub fn base_path(&mut self) -> &[String] {
+        &self.path[0..self.base_path_len]
+    }
+
+    /// Get the relative path.
+    pub fn relative_path(&mut self) -> &[String] {
+        &self.path[self.base_path_len..]
+    }
 
     /// Get the hash path.
     pub fn hash_path(&self) -> &[String] {

--- a/src/browser/url/search.rs
+++ b/src/browser/url/search.rs
@@ -1,6 +1,6 @@
+use super::Url;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::BTreeMap, fmt};
-use super::Url;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -138,13 +138,14 @@ impl From<web_sys::UrlSearchParams> for UrlSearch {
 }
 
 impl<K, V, VS> std::iter::FromIterator<(K, VS)> for UrlSearch
-    where
-        K: Into<String>,
-        V: Into<String>,
-        VS: IntoIterator<Item = V>,
+where
+    K: Into<String>,
+    V: Into<String>,
+    VS: IntoIterator<Item = V>,
 {
     fn from_iter<I: IntoIterator<Item = (K, VS)>>(iter: I) -> Self {
-        let search = iter.into_iter()
+        let search = iter
+            .into_iter()
             .map(|(k, vs)| {
                 let k = k.into();
                 let v: Vec<_> = vs.into_iter().map(Into::into).collect();
@@ -159,17 +160,16 @@ impl<K, V, VS> std::iter::FromIterator<(K, VS)> for UrlSearch
 }
 
 impl<'a, K, V, VS> std::iter::FromIterator<&'a (K, VS)> for UrlSearch
-    where
-        K: 'a,
-        &'a K: Into<String>,
-        V: Into<String>,
-        VS: 'a,
-        &'a VS: IntoIterator<Item = V>,
+where
+    K: 'a,
+    &'a K: Into<String>,
+    V: Into<String>,
+    VS: 'a,
+    &'a VS: IntoIterator<Item = V>,
 {
     fn from_iter<I: IntoIterator<Item = &'a (K, VS)>>(iter: I) -> Self {
-        iter.into_iter().map(|(k, vs)| (
-            k.into(),
-            vs.into_iter(),
-        )).collect()
+        iter.into_iter()
+            .map(|(k, vs)| (k.into(), vs.into_iter()))
+            .collect()
     }
 }

--- a/src/browser/url/search.rs
+++ b/src/browser/url/search.rs
@@ -1,0 +1,159 @@
+use serde::{Deserialize, Serialize};
+use std::{borrow::Cow, collections::BTreeMap, fmt};
+
+use super::Url;
+
+// ------ UrlSearch ------
+
+#[allow(clippy::module_name_repetitions)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UrlSearch {
+    search: BTreeMap<String, Vec<String>>,
+    pub(super) invalid_components: Vec<String>,
+}
+
+impl UrlSearch {
+    /// Makes a new `UrlSearch` with the provided parameters.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// UrlSearch::new(vec![
+    ///     ("sort", vec!["date", "name"]),
+    ///     ("category", vec!["top"])
+    /// ])
+    /// ```
+    pub fn new<K, V, VS>(params: impl IntoIterator<Item = (K, VS)>) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+        VS: IntoIterator<Item = V>,
+    {
+        let mut search = BTreeMap::new();
+        for (key, values) in params {
+            search.insert(key.into(), values.into_iter().map(Into::into).collect());
+        }
+        Self {
+            search,
+            invalid_components: Vec::new(),
+        }
+    }
+
+    /// Returns `true` if the `UrlSearch` contains a value for the specified key.
+    pub fn contains_key(&self, key: impl AsRef<str>) -> bool {
+        self.search.contains_key(key.as_ref())
+    }
+
+    /// Returns a reference to values corresponding to the key.
+    pub fn get(&self, key: impl AsRef<str>) -> Option<&Vec<String>> {
+        self.search.get(key.as_ref())
+    }
+
+    /// Returns a mutable reference to values corresponding to the key.
+    pub fn get_mut(&mut self, key: impl AsRef<str>) -> Option<&mut Vec<String>> {
+        self.search.get_mut(key.as_ref())
+    }
+
+    /// Push the value into the vector of values corresponding to the key.
+    /// - If the key and values are not present, they will be crated.
+    pub fn push_value<'a>(&mut self, key: impl Into<Cow<'a, str>>, value: String) {
+        let key = key.into();
+        if self.search.contains_key(key.as_ref()) {
+            self.search.get_mut(key.as_ref()).unwrap().push(value);
+        } else {
+            self.search.insert(key.into_owned(), vec![value]);
+        }
+    }
+
+    /// Inserts a key-values pair into the `UrlSearch`.
+    /// - If the `UrlSearch` did not have this key present, `None` is returned.
+    /// - If the `UrlSearch` did have this key present, old values are overwritten by new ones,
+    /// and old values are returned. The key is not updated.
+    pub fn insert(&mut self, key: String, values: Vec<String>) -> Option<Vec<String>> {
+        self.search.insert(key, values)
+    }
+
+    /// Removes a key from the `UrlSearch`, returning values at the key
+    /// if the key was previously in the `UrlSearch`.
+    pub fn remove(&mut self, key: impl AsRef<str>) -> Option<Vec<String>> {
+        self.search.remove(key.as_ref())
+    }
+
+    /// Gets an iterator over the entries of the `UrlSearch`, sorted by key.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Vec<String>)> {
+        self.search.iter()
+    }
+
+    /// Get invalid components.
+    ///
+    /// Undecodable / unparsable components are invalid.
+    pub fn invalid_components(&self) -> &[String] {
+        &self.invalid_components
+    }
+
+    /// Get mutable invalid components.
+    ///
+    /// Undecodable / unparsable components are invalid.
+    pub fn invalid_components_mut(&mut self) -> &mut Vec<String> {
+        &mut self.invalid_components
+    }
+}
+
+/// `UrlSearch` components are automatically encoded.
+impl fmt::Display for UrlSearch {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let params = web_sys::UrlSearchParams::new().expect("create a new UrlSearchParams");
+
+        for (key, values) in &self.search {
+            for value in values {
+                params.append(key, value);
+            }
+        }
+        write!(fmt, "{}", String::from(params.to_string()))
+    }
+}
+
+impl From<web_sys::UrlSearchParams> for UrlSearch {
+    /// Creates a new `UrlSearch` from the browser native `UrlSearchParams`.
+    /// `UrlSearch`'s components are decoded if possible. When decoding fails, the component is cloned
+    /// into `invalid_components` and the original value is used.
+    fn from(params: web_sys::UrlSearchParams) -> Self {
+        let mut url_search = Self::default();
+        let mut invalid_components = Vec::<String>::new();
+
+        for param in js_sys::Array::from(&params).to_vec() {
+            let key_value_pair = js_sys::Array::from(&param).to_vec();
+
+            let key = key_value_pair
+                .get(0)
+                .expect("get UrlSearchParams key from key-value pair")
+                .as_string()
+                .expect("cast UrlSearchParams key to String");
+            let value = key_value_pair
+                .get(1)
+                .expect("get UrlSearchParams value from key-value pair")
+                .as_string()
+                .expect("cast UrlSearchParams value to String");
+
+            let key = match Url::decode_uri_component(&key) {
+                Ok(decoded_key) => decoded_key,
+                Err(_) => {
+                    invalid_components.push(key.clone());
+                    key
+                }
+            };
+            let value = match Url::decode_uri_component(&value) {
+                Ok(decoded_value) => decoded_value,
+                Err(_) => {
+                    invalid_components.push(value.clone());
+                    value
+                }
+            };
+
+            url_search.push_value(key, value)
+        }
+
+        url_search.invalid_components = invalid_components;
+        url_search
+    }
+}


### PR DESCRIPTION
Mostly cosmetic changes, reorganization, and edits to the documentation.

The biggest change here is probably with the `UrlSearch` struct's `FromIterator` impl as well as how `UrlSearch` has been extracted into `seed::browser::url::search` (but reexported).

The documentation part was left out, mostly because I'm not entirely sure what would qualify as "most common" use cases.

Should handle most of #433, but all changes are up for discussion.

Also related to #383.