### PR TITLE
Fix: Double UrlChanged firing (setup_hashchange_listener removed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [BREAKING] Removed deprecated `Ev::TriggerUpdate`.
 - [deprecated] `simple_ev` is deprecated.
 - Exposed dependency `console_error_panic_hook`.
+- Fixed double `UrlChanged` firing by removing `hashchange` listener.
 
 ## v0.7.0
 - [BREAKING] Custom elements are now patched in-place (#364). Use `el_key` to force reinitialize an element.

--- a/src/app.rs
+++ b/src/app.rs
@@ -202,13 +202,6 @@ where
             enc!((app => s) move |notification| s.notify_with_notification(notification)),
             Rc::clone(&app.cfg.base_path),
         );
-        routing::setup_hashchange_listener(
-            enc!((app => s) move |closure| {
-                s.data.hashchange_closure.replace(Some(closure));
-            }),
-            enc!((app => s) move |notification| s.notify_with_notification(notification)),
-            Rc::clone(&app.cfg.base_path),
-        );
         routing::setup_link_listener(
             enc!((app => s) move |notification| s.notify_with_notification(notification)),
         );

--- a/src/browser/service/routing.rs
+++ b/src/browser/service/routing.rs
@@ -22,7 +22,6 @@ pub fn push_route<U: Into<Url>>(url: U) -> Url {
     url
 }
 
-// Add a listener that handles routing for navigation events like forward and back.
 pub fn setup_popstate_listener(
     updated_listener: impl Fn(Closure<dyn FnMut(web_sys::Event)>) + 'static,
     notify: impl Fn(Notification) + 'static,
@@ -49,35 +48,6 @@ pub fn setup_popstate_listener(
     (util::window().as_ref() as &web_sys::EventTarget)
         .add_event_listener_with_callback("popstate", closure.as_ref().unchecked_ref())
         .expect("Problem adding popstate listener");
-
-    updated_listener(closure);
-}
-
-// Add a listener that handles routing when the url hash is changed.
-pub fn setup_hashchange_listener(
-    updated_listener: impl Fn(Closure<dyn FnMut(web_sys::Event)>) + 'static,
-    notify: impl Fn(Notification) + 'static,
-    base_path: Rc<Vec<String>>,
-) {
-    // todo: DRY with popstate listener
-    let closure = Closure::new(move |ev: web_sys::Event| {
-        let ev = ev
-            .dyn_ref::<web_sys::HashChangeEvent>()
-            .expect("Problem casting as hashchange event");
-
-        let url: Url = ev
-            .new_url()
-            .parse()
-            .expect("cast hashchange event url to `Url`");
-
-        notify(Notification::new(subs::UrlChanged(
-            url.skip_base_path(&base_path),
-        )));
-    });
-
-    (util::window().as_ref() as &web_sys::EventTarget)
-        .add_event_listener_with_callback("hashchange", closure.as_ref().unchecked_ref())
-        .expect("Problem adding hashchange listener");
 
     updated_listener(closure);
 }


### PR DESCRIPTION
This PR removes `hashchange` listener because it was causing double `UrlChanged` firing (one from `hashchange` listener and one from `popstate` listener). 

I haven't found a case where `hashchange` is fired and `popstate` not. 