### PR TITLE
fix: use submit event on form instead and simplify code

### DIFF
--- a/examples/fetch/src/post.rs
+++ b/examples/fetch/src/post.rs
@@ -81,7 +81,7 @@ pub fn view(model: &Model) -> Node<Msg> {
                 input_ev(Ev::Input, Msg::NameChanged),
             ]
         ],
-        button!["Submit",],
+        button!["Submit"],
         if let Some(message) = &model.message {
             span![message]
         } else {

--- a/examples/fetch/src/post.rs
+++ b/examples/fetch/src/post.rs
@@ -70,7 +70,10 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
 
 pub fn view(model: &Model) -> Node<Msg> {
     form![
-        ev(Ev::Submit, |_| Msg::Submit),
+        ev(Ev::Submit, |event| {
+            event.prevent_default();
+            Msg::Submit
+        }),
         label![
             "Name",
             input![
@@ -78,13 +81,7 @@ pub fn view(model: &Model) -> Node<Msg> {
                 input_ev(Ev::Input, Msg::NameChanged),
             ]
         ],
-        button![
-            "Submit",
-            ev(Ev::Click, |event| {
-                event.prevent_default();
-                Msg::Submit
-            })
-        ],
+        button!["Submit",],
         if let Some(message) = &model.message {
             span![message]
         } else {


### PR DESCRIPTION
Hello guys !

One of the joy I have with `seed` is that I rediscover pure html :+1: 
Anyway, yesterday I realized that the submit event on a form and a button are not the same and that our nice example from fetch could be improved.

It is simpler and also better to use the submit even from the form since it will also pop only if the form is valid :)

PS: is it fine to have a comma inside `button!["Submit",]` or is there a standard for that ?
I can remove it if needed