### PR TITLE
Annotate fetch::Response with derive Debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Added `WebSocket` + related items (#8).
 - Exposed `App::mailbox`.
 - Added `streams::backoff` + updated `websocket` example.
+- Added `#[derive(Debug)]` to `fetch::Response`
 
 ## v0.6.0
 - Implemented `UpdateEl` for `Filter` and `FilterMap`.

--- a/src/browser/fetch/response.rs
+++ b/src/browser/fetch/response.rs
@@ -8,6 +8,7 @@ use wasm_bindgen_futures::JsFuture;
 /// To get one you need to use [`fetch`](./fn.fetch.html) function.
 ///
 /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Response)
+#[derive(Debug)]
 pub struct Response {
     pub(crate) raw_response: web_sys::Response,
 }


### PR DESCRIPTION
the underlying web_sys::Response implements debug, so may as well take advantage of it. 