### PR TITLE
prevent system from intercepting links with a download attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [unreleased]
 - [BREAKING] Base path changed from `Rc<Vec<String>>` to `Rc<[String]>`. It means also `Orders::clone_base_path` returns a slice.
+- Prevent link listener from intercepting links with the `download` attribute.
 
 ## v0.8.0
 - [BREAKING] Rename `linear_gradient!` to `linearGradient!` for consistency with the other svg macros (same with `radial_gradient!` and `mesh_gradient!`) (#377).

--- a/src/browser/service/routing.rs
+++ b/src/browser/service/routing.rs
@@ -87,7 +87,13 @@ pub fn setup_link_listener(notify: impl Fn(Notification) + 'static) {
         event.target()
             .and_then(|et| et.dyn_into::<web_sys::Element>().ok())
             .and_then(|el| el.closest("a[href]").ok().flatten())
-            .and_then(|href_el| href_el.get_attribute("href"))
+            .and_then(|href_el| {
+                if href_el.has_attribute("download") {
+                    None
+                } else {
+                    href_el.get_attribute("href")
+                }
+            })
             // The first character being / or empty href indicates a rel link, which is what
             // we're intercepting.
             // @TODO: Resolve it properly, see Elm implementation:


### PR DESCRIPTION
This PR prevents seed from intercepting links with a download attributes

```html
<a download="filename.ext" href="/files/filename.ext">filename.ext</a>
```
