### PR TITLE
Hide `console_error_panic_hook` behind `panic-hook` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added examples `record_screen`, `e2e_encryption` and `counters`.
 - Adapted to Rust 1.50.0.
 - Added `Response::blob`
+- Added `panic-hook` feature, enabled by default, to conditionally include `console_error_panic_hook`
 
 ## v0.8.0
 - [BREAKING] Rename `linear_gradient!` to `linearGradient!` for consistency with the other svg macros (same with `radial_gradient!` and `mesh_gradient!`) (#377).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ version_check = "0.9.2"
 wasm-bindgen-test = "0.3.20"
 
 [dependencies]
-console_error_panic_hook = "0.1.6"
+console_error_panic_hook = { version = "0.1.6", optional = true }
 cookie = { version = "0.14.2", features = ["percent-encode"] }
 enclose = "1.1.8"
 gloo-timers = { version = "0.2.1", features = ["futures"] }
@@ -157,3 +157,7 @@ exclude = [
     "examples/e2e_encryption",
     "examples/server_integration",
 ]
+
+[features]
+default = ["panic-hook"]
+panic-hook = ["console_error_panic_hook"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -145,6 +145,7 @@ where
         std::mem::drop(util::document().query_selector("html"));
 
         // Allows panic messages to output to the browser console.error.
+        #[cfg(feature = "panic-hook")]
         console_error_panic_hook::set_once();
 
         let base_path: Rc<[String]> = Rc::from(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,10 @@ pub use crate::{
     },
     virtual_dom::{Attrs, EventHandler, Style},
 };
+
+#[cfg(feature = "panic-hook")]
 pub use console_error_panic_hook;
+
 pub use futures::{
     self,
     future::{self, FutureExt, TryFutureExt},


### PR DESCRIPTION
Adds a `panic-hook` feature, enabled by default, to be able to conditionally disable the panic hook set in `App::start` This is necessary to be able to use a custom panic hook that will also catch errors that might occur during `App::start`.