### PR TITLE
fix: Don't rerender or process effects queue when there is a panic

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -249,6 +249,10 @@ where
     }
 
     pub(crate) fn process_effect_queue(&self, mut queue: VecDeque<Effect<Ms>>) {
+        if std::thread::panicking() {
+            return;
+        }
+
         while let Some(effect) = queue.pop_front() {
             match effect {
                 Effect::Msg(msg) => {
@@ -328,6 +332,10 @@ where
     }
 
     fn rerender_vdom(&self) {
+        if std::thread::panicking() {
+            return;
+        }
+
         let new_render_timestamp = window().performance().expect("get `Performance`").now();
 
         // Create a new vdom: The top element, and all its children. Does not yet


### PR DESCRIPTION
When user code panics you can often see
```
panicked at 'already mutably borrowed: BorrowError', ./seed/src/app.rs:344:56
```

As unwinding is not yet implemented for WASM there is no way we can
recover from the panic. In other words if `view` or `update` panics,
model will remain borrowed and always lead to panic in seed.

That error is confusing for the user. It's also unwanted when one
wants to use custom panic hook.

This PR prevents `BorrowError` by checking for already happening panic.