### PR TITLE
refactor: hide markdown functionality behind optional feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Adapted to Rust 1.50.0.
 - Added `Response::blob`
 - Added `panic-hook` feature, enabled by default, to conditionally include `console_error_panic_hook`
+- [BREAKING] Hid markdown funnctionality behind optional `markdown` feature
 
 ## v0.8.0
 - [BREAKING] Rename `linear_gradient!` to `linearGradient!` for consistency with the other svg macros (same with `radial_gradient!` and `mesh_gradient!`) (#377).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ gloo-timers = { version = "0.2.1", features = ["futures"] }
 gloo-file = { version = "0.1.0", features = ["futures"] }
 indexmap = "1.6.0"
 js-sys = "0.3.47"
-pulldown-cmark = "0.8.0"
+pulldown-cmark = { version = "0.8.0", optional = true }
 rand = { version = "0.8.0", features = ["small_rng"] }
 # https://docs.rs/getrandom/0.2.0/getrandom/#webassembly-support
 getrandom = { version = "0.2", features = ["js"] }
@@ -161,3 +161,4 @@ exclude = [
 [features]
 default = ["panic-hook"]
 panic-hook = ["console_error_panic_hook"]
+markdown = ["pulldown-cmark"]

--- a/examples/el_key/Cargo.toml
+++ b/examples/el_key/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-seed = { path = "../../" }
+seed = { path = "../../", features = ["markdown"] }
 rand = { version = "0.7.3", features = ["wasm-bindgen", "small_rng"] }
 scarlet = "1.1.0"
 static_assertions = "1.1.0"

--- a/examples/markdown/Cargo.toml
+++ b/examples/markdown/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["cdylib"]
 pulldown-cmark = "0.8.0"
 
 [dependencies]
-seed = {path = "../../"}
+seed = { path = "../../", features = ["markdown"] }

--- a/src/virtual_dom/node.rs
+++ b/src/virtual_dom/node.rs
@@ -49,6 +49,7 @@ impl<Ms> fmt::Display for Node<Ms> {
 // Element methods
 impl<Ms> Node<Ms> {
     /// See `El::from_markdown`
+    #[cfg(feature = "markdown")]
     pub fn from_markdown(markdown: &str) -> Vec<Node<Ms>> {
         El::from_markdown(markdown)
     }

--- a/src/virtual_dom/node/el.rs
+++ b/src/virtual_dom/node/el.rs
@@ -168,7 +168,8 @@ impl<Ms> El<Ms> {
 
     // todo: Return El instead of Node here? (Same with from_html)
     /// Create elements from a markdown string.
-    /// _Note:_ All additional markdown [extensions](https://docs.rs/pulldown-cmark/latest/pulldown_cmark/struct.Options.html) enabled.
+    /// _Note:_ Requires the `markdown` feature. All additional markdown [extensions](https://docs.rs/pulldown-cmark/latest/pulldown_cmark/struct.Options.html) enabled.
+    #[cfg(feature = "markdown")]
     pub fn from_markdown(markdown: &str) -> Vec<Node<Ms>> {
         let options = pulldown_cmark::Options::all();
 


### PR DESCRIPTION
Just to lighten the payload a little. I've probably missed something though, and if so just let me know.