### PR TITLE
refactor(examples/component_builder): declone Msg and simplify click handler

### DIFF
--- a/examples/animation/src/lib.rs
+++ b/examples/animation/src/lib.rs
@@ -68,12 +68,12 @@ impl Default for Car {
 //    Update
 // ------ ------
 
-#[derive(Copy, Clone)]
 enum Msg {
     Rendered(RenderInfo),
     SetViewportWidth,
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     match msg {
         Msg::Rendered(render_info) => {

--- a/examples/canvas/src/lib.rs
+++ b/examples/canvas/src/lib.rs
@@ -51,12 +51,12 @@ impl Default for Color {
 //    Update
 // ------ ------
 
-#[derive(Copy, Clone)]
 enum Msg {
     Rendered,
     ChangeColor,
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     match msg {
         Msg::Rendered => {

--- a/examples/component_builder/src/button.rs
+++ b/examples/component_builder/src/button.rs
@@ -4,7 +4,7 @@ use seed::virtual_dom::IntoNodes;
 use seed::{prelude::*, Style as Css, *};
 use std::borrow::Cow;
 use std::rc::Rc;
-use web_sys::{HtmlElement, MouseEvent};
+use web_sys::HtmlElement;
 
 // ------ Button ------
 
@@ -17,7 +17,7 @@ pub struct Button<Ms: 'static> {
     element: Element,
     attrs: Attrs,
     disabled: bool,
-    on_clicks: Vec<Rc<dyn Fn(MouseEvent) -> Ms>>,
+    on_clicks: Vec<Rc<dyn Fn() -> Ms>>,
     content: Vec<Node<Ms>>,
     el_ref: ElRef<HtmlElement>,
     css: Css,
@@ -110,12 +110,8 @@ impl<Ms> Button<Ms> {
         self
     }
 
-    pub fn add_on_click(
-        mut self,
-        on_click: impl FnOnce(MouseEvent) -> Ms + Clone + 'static,
-    ) -> Self {
-        self.on_clicks
-            .push(Rc::new(move |event| on_click.clone()(event)));
+    pub fn add_on_click(mut self, on_click: impl FnOnce() -> Ms + Clone + 'static) -> Self {
+        self.on_clicks.push(Rc::new(move || on_click.clone()()));
         self
     }
 
@@ -217,7 +213,7 @@ impl<Ms> Button<Ms> {
 
         if !self.disabled {
             for on_click in self.on_clicks {
-                button.add_event_handler(mouse_ev(Ev::Click, move |event| on_click(event)));
+                button.add_event_handler(ev(Ev::Click, move |_| on_click()));
             }
         }
 

--- a/examples/component_builder/src/lib.rs
+++ b/examples/component_builder/src/lib.rs
@@ -21,12 +21,12 @@ type Model = i32;
 //    Update
 // ------ ------
 
-#[derive(Copy, Clone)]
 enum Msg {
     Increment,
     Decrement,
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
     match msg {
         Msg::Increment => *model += 1,

--- a/examples/component_builder/src/lib.rs
+++ b/examples/component_builder/src/lib.rs
@@ -44,23 +44,23 @@ fn view(model: &Model) -> Node<Msg> {
         style! { St::Display => "flex" },
         Button::new("-")
             .disabled(true)
-            .add_on_click(|_| Msg::Decrement),
+            .add_on_click(|| Msg::Decrement),
         Button::new("-")
             .secondary()
             .large()
             .outline()
-            .add_on_click(|_| Msg::Decrement),
-        Button::new("-").add_on_click(|_| Msg::Decrement),
+            .add_on_click(|| Msg::Decrement),
+        Button::new("-").add_on_click(|| Msg::Decrement),
         div![model],
-        Button::new("+").add_on_click(|_| Msg::Increment),
+        Button::new("+").add_on_click(|| Msg::Increment),
         Button::new("+")
             .secondary()
             .large()
             .outline()
-            .add_on_click(|_| Msg::Increment),
+            .add_on_click(|| Msg::Increment),
         Button::new("+")
             .disabled(true)
-            .add_on_click(|_| Msg::Increment),
+            .add_on_click(|| Msg::Increment),
         Button::new("seed-rs.org").a("https://seed-rs.org"),
     ]
 }

--- a/examples/counters/src/lib.rs
+++ b/examples/counters/src/lib.rs
@@ -26,11 +26,11 @@ struct Model {
 //    Update
 // ------ ------
 
-#[derive(Clone, Copy)]
 enum Msg {
     Counter(counter::Msg, CounterId),
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
     match msg {
         Msg::Counter(msg, id) => counter::update(msg, &mut model.counters[id]),

--- a/examples/custom_elements/src/lib.rs
+++ b/examples/custom_elements/src/lib.rs
@@ -26,11 +26,11 @@ struct Model {
 //    Update
 // ------ ------
 
-#[derive(Copy, Clone)]
 enum Msg {
     RotateCheckboxState,
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
     match msg {
         Msg::RotateCheckboxState => model.checkbox_state = model.checkbox_state.next(),

--- a/examples/el_key/src/lib.rs
+++ b/examples/el_key/src/lib.rs
@@ -118,7 +118,7 @@ enum Drag {
 //    Update
 // ------ ------
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 enum Msg {
     // ------ Selecting ------
     SelectNone,
@@ -144,6 +144,7 @@ enum Msg {
     ToggleEmpty,
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     log!("update:", msg);
     match msg {

--- a/examples/resize_observer/src/lib.rs
+++ b/examples/resize_observer/src/lib.rs
@@ -52,7 +52,6 @@ struct Model {
 //    Update
 // ------ ------
 
-#[derive(Copy, Clone)]
 enum Msg {
     Resized(f64, f64),
 }

--- a/examples/rust_from_js/src/lib.rs
+++ b/examples/rust_from_js/src/lib.rs
@@ -30,11 +30,11 @@ struct Model;
 //    Update
 // ------ ------
 
-#[derive(Clone, Copy)]
 enum Msg {
     Rerender,
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn update(msg: Msg, _: &mut Model, _: &mut impl Orders<Msg>) {
     match msg {
         Msg::Rerender => log!("Rerendered"),

--- a/examples/tea_component/src/counter.rs
+++ b/examples/tea_component/src/counter.rs
@@ -16,12 +16,12 @@ pub struct Model {
 //    Update
 // ------ ------
 
-#[derive(Copy, Clone)]
 pub enum Msg {
     Increment,
     Decrement,
 }
 
+#[allow(clippy::needless_pass_by_value)]
 pub fn update<Ms: 'static>(
     msg: Msg,
     model: &mut Model,

--- a/examples/tea_component/src/lib.rs
+++ b/examples/tea_component/src/lib.rs
@@ -28,7 +28,6 @@ struct Model {
 // ------ ------
 
 #[allow(clippy::enum_variant_names)]
-#[derive(Copy, Clone)]
 enum Msg {
     CounterA(counter::Msg),
     CounterB(counter::Msg),


### PR DESCRIPTION
As suggested in #584.

`Clone` is actually not needed on `Msg` because of the event handler, but because clippy is being a bit anal. So to reduce confusion I've removed the derive and disabled the clippy warning instead. (edit: also done for all other examples now)

I've also simplified the event handler a bit by removing the `MouseEvent` argument, partly because I think it's good design in general to not expose unnecessary implementation details, but also partly because it illustrates that `Msg`s must be passed in as a closure even if it doesn't take any arguments, unless it implements `Clone`.