### PR TITLE
Add helpers for wheel event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [unreleased]
+- Added helpers for wheel event: `wheel_ev` and `to_wheel_event`.
+- Use `wheel_ev` in `canvas` example to zoom rectangle with mouse scroll wheel.
 - [BREAKING] Base path changed from `Rc<Vec<String>>` to `Rc<[String]>`. It means also `Orders::clone_base_path` returns a slice.
 - Prevent link listener from intercepting links with the `download` attribute.
 - Added examples `record_screen`, `e2e_encryption` and `counters`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ features = [
     "Window",
     "KeyboardEvent",
     "InputEvent",
+    "WheelEvent",
     "Url",
     "UrlSearchParams",
 ]

--- a/examples/canvas/src/lib.rs
+++ b/examples/canvas/src/lib.rs
@@ -3,7 +3,7 @@
 //! [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawWindow)
 
 use seed::{prelude::*, *};
-use web_sys::{HtmlCanvasElement, WheelEvent};
+use web_sys::HtmlCanvasElement;
 
 // ------ ------
 //     Init
@@ -63,7 +63,7 @@ impl Default for Color {
 
 enum Zoom {
     In,
-    Out
+    Out,
 }
 
 enum Msg {
@@ -137,11 +137,7 @@ fn view(model: &Model) -> impl IntoNodes<Msg> {
                 let delta_y = event.delta_y();
                 (delta_y != 0.0).then(|| {
                     event.prevent_default();
-                    Msg::Zoom(if delta_y < 0.0 {
-                        Zoom::In
-                    } else {
-                        Zoom::Out
-                    })
+                    Msg::Zoom(if delta_y < 0.0 { Zoom::In } else { Zoom::Out })
                 })
             }),
         ],

--- a/src/browser/dom/cast.rs
+++ b/src/browser/dom/cast.rs
@@ -60,3 +60,10 @@ pub fn to_drag_event(event: &web_sys::Event) -> &web_sys::DragEvent {
         .dyn_ref::<web_sys::DragEvent>()
         .expect("Unable to cast as a drag event")
 }
+
+/// See `to_keyboard_event`
+pub fn to_wheel_event(event: &web_sys::Event) -> &web_sys::WheelEvent {
+    event
+        .dyn_ref::<web_sys::WheelEvent>()
+        .expect("Unable to cast as a wheel event")
+}

--- a/src/browser/dom/event_handler.rs
+++ b/src/browser/dom/event_handler.rs
@@ -128,6 +128,25 @@ pub fn pointer_ev<Ms: 'static, MsU: 'static>(
     EventHandler::new(trigger, handler)
 }
 
+/// See `keyboard_ev`
+#[allow(clippy::shadow_unrelated)]
+#[allow(clippy::missing_panics_doc)]
+pub fn wheel_ev<Ms: 'static, MsU: 'static>(
+    trigger: impl Into<Ev>,
+    handler: impl FnOnce(web_sys::WheelEvent) -> MsU + 'static + Clone,
+) -> EventHandler<Ms> {
+    let handler = map_callback_return_to_option_ms!(
+        dyn Fn(web_sys::WheelEvent) -> Option<Ms>,
+        handler.clone(),
+        "Handler can return only Msg, Option<Msg> or ()!",
+        Rc
+    );
+    let handler = move |event: web_sys::Event| {
+        handler(event.dyn_ref::<web_sys::WheelEvent>().unwrap().clone())
+    };
+    EventHandler::new(trigger, handler)
+}
+
 /// Create an event that accepts a closure, and passes a `web_sys::Event`, allowing full control of
 /// event-handling.
 #[deprecated(since = "0.6.0", note = "Use `ev` instead.")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub use crate::{
     app::App,
     browser::dom::cast::{
         to_drag_event, to_html_el, to_input, to_keyboard_event, to_mouse_event, to_select,
-        to_textarea, to_touch_event,
+        to_textarea, to_touch_event, to_wheel_event,
     },
     browser::fetch,
     browser::url::Url,
@@ -182,6 +182,7 @@ pub mod prelude {
         browser::dom::css_units::*,
         browser::dom::event_handler::{
             drag_ev, ev, input_ev, keyboard_ev, mouse_ev, pointer_ev, raw_ev, simple_ev, touch_ev,
+            wheel_ev,
         },
         browser::dom::Namespace,
         browser::fetch::{self, fetch, FetchError, Header, Method, Request, Response, Status},


### PR DESCRIPTION
- add helpers
  - `wheel_ev` - see `keyboard_ev`
  - `to_wheel_event` - see `to_keyboard_event`
- use `wheel_ev` in `canvas` example
  - scrolling the mouse wheel while the mouse pointer is within the canvas zooms the rectangle