### PR TITLE
Experimental component API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added macro `raw_svg!` (#589).
 - Added `browser::dom::Namespace` to `prelude`. 
 - Adapted to Rust 1.51.0.
+- Added an experimental component API, feature-flagged behind `experimental-component-api`, and the `experimental-component` example to demonstrate its use.
 
 ## v0.8.0
 - [BREAKING] Rename `linear_gradient!` to `linearGradient!` for consistency with the other svg macros (same with `radial_gradient!` and `mesh_gradient!`) (#377).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "experimental_component"
+version = "0.1.0"
+dependencies = [
+ "seed",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,3 +164,4 @@ exclude = [
 default = ["panic-hook"]
 panic-hook = ["console_error_panic_hook"]
 markdown = ["pulldown-cmark"]
+experimental-component-api = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ members = [
     "examples/custom_elements",
     "examples/drop_zone",
     "examples/el_key",
+    "examples/experimental_component",
     "examples/graphql",
     "examples/i18n",
     "examples/markdown",

--- a/examples/experimental_component/Cargo.toml
+++ b/examples/experimental_component/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "experimental_component"
+version = "0.1.0"
+authors = ["glennsl"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+seed = {path = "../../"}

--- a/examples/experimental_component/Cargo.toml
+++ b/examples/experimental_component/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-seed = {path = "../../"}
+seed = { path = "../../", features = ["experimental-component-api"] }

--- a/examples/experimental_component/Makefile.toml
+++ b/examples/experimental_component/Makefile.toml
@@ -1,0 +1,27 @@
+extend = "../../Makefile.toml"
+
+# ---- BUILD ----
+
+[tasks.build]
+alias = "default_build"
+
+[tasks.build_release]
+alias = "default_build_release"
+
+# ---- START ----
+
+[tasks.start]
+alias = "default_start"
+
+[tasks.start_release]
+alias = "default_start_release"
+
+# ---- TEST ----
+
+[tasks.test_firefox]
+alias = "default_test_firefox"
+
+# ---- LINT ----
+
+[tasks.clippy]
+alias = "default_clippy"

--- a/examples/experimental_component/README.md
+++ b/examples/experimental_component/README.md
@@ -1,0 +1,16 @@
+## Experimental component API example
+
+Demonstrates a component API that has:
+
+- Labeled required properties, ensured to be present at compile-time
+- Labeled optional properties
+- Polymorphic for all properties
+- A convenient consumer interface, through a stupidly simple macro that is very easy to understand
+
+---
+
+```bash
+cargo make start
+```
+
+Open [127.0.0.1:8000](http://127.0.0.1:8000) in your browser.

--- a/examples/experimental_component/README.md
+++ b/examples/experimental_component/README.md
@@ -1,11 +1,6 @@
 ## Experimental component API example
 
-Demonstrates a component API that has:
-
-- Labeled required properties, ensured to be present at compile-time
-- Labeled optional properties
-- Polymorphic for all properties
-- A convenient consumer interface, through a stupidly simple macro that is very easy to understand
+Demonstrates how to use the experimental component API.
 
 ---
 

--- a/examples/experimental_component/index.html
+++ b/examples/experimental_component/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <title>Experimental component API example</title>
+</head>
+
+<body>
+  <section id="app"></section>
+  <script type="module">
+    import init from '/pkg/package.js';
+    init('/pkg/package_bg.wasm');
+  </script>
+</body>
+
+</html>

--- a/examples/experimental_component/src/button.rs
+++ b/examples/experimental_component/src/button.rs
@@ -1,0 +1,94 @@
+#![allow(dead_code)]
+
+use seed::{prelude::*, *};
+use std::borrow::Cow;
+use std::rc::Rc;
+
+pub struct Button<S> {
+    pub label: S,
+}
+
+impl<S: Into<Cow<'static, str>>> Button<S> {
+    pub fn into_component<Ms>(self) -> Component<Ms> {
+        Component {
+            label: self.label.into(),
+            outlined: false,
+            disabled: false,
+            on_clicks: Vec::new(),
+        }
+    }
+}
+
+pub struct Component<Ms: 'static> {
+    label: Cow<'static, str>,
+    outlined: bool,
+    disabled: bool,
+    on_clicks: Vec<Rc<dyn Fn() -> Ms>>,
+}
+
+impl<Ms> Component<Ms> {
+    pub const fn outlined(mut self, outlined: bool) -> Self {
+        self.outlined = outlined;
+        self
+    }
+
+    pub const fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    pub fn on_click(mut self, on_click: impl FnOnce() -> Ms + Clone + 'static) -> Self {
+        self.on_clicks.push(Rc::new(move || on_click.clone()()));
+        self
+    }
+
+    pub fn into_node(self) -> Node<Ms> {
+        let attrs = {
+            let mut attrs = attrs! {};
+
+            if self.disabled {
+                attrs.add(At::from("aria-disabled"), true);
+                attrs.add(At::TabIndex, -1);
+                attrs.add(At::Disabled, AtValue::None);
+            }
+
+            attrs
+        };
+
+        let css = {
+            let color = "teal";
+
+            let mut css = style! {
+                St::TextDecoration => "none",
+            };
+
+            if self.outlined {
+                css.merge(style! {
+                    St::Color => color,
+                    St::BackgroundColor => "transparent",
+                    St::Border => format!("{} {} {}", px(2), "solid", color),
+                });
+            } else {
+                css.merge(style! { St::Color => "white", St::BackgroundColor => color });
+            };
+
+            if self.disabled {
+                css.merge(style! {St::Opacity => 0.5});
+            } else {
+                css.merge(style! {St::Cursor => "pointer"});
+            }
+
+            css
+        };
+
+        let mut button = button![css, attrs, self.label];
+
+        if !self.disabled {
+            for on_click in self.on_clicks {
+                button.add_event_handler(ev(Ev::Click, move |_| on_click()));
+            }
+        }
+
+        button
+    }
+}

--- a/examples/experimental_component/src/button.rs
+++ b/examples/experimental_component/src/button.rs
@@ -9,8 +9,8 @@ pub struct Button<S> {
 }
 
 impl<S: Into<Cow<'static, str>>> Button<S> {
-    pub fn into_component<Ms>(self) -> Component<Ms> {
-        Component {
+    pub fn into_component<Ms>(self) -> ButtonComponent<Ms> {
+        ButtonComponent {
             label: self.label.into(),
             outlined: false,
             disabled: false,
@@ -19,14 +19,15 @@ impl<S: Into<Cow<'static, str>>> Button<S> {
     }
 }
 
-pub struct Component<Ms: 'static> {
+#[allow(clippy::module_name_repetitions)]
+pub struct ButtonComponent<Ms: 'static> {
     label: Cow<'static, str>,
     outlined: bool,
     disabled: bool,
     on_clicks: Vec<Rc<dyn Fn() -> Ms>>,
 }
 
-impl<Ms> Component<Ms> {
+impl<Ms> ButtonComponent<Ms> {
     pub const fn outlined(mut self, outlined: bool) -> Self {
         self.outlined = outlined;
         self
@@ -41,8 +42,10 @@ impl<Ms> Component<Ms> {
         self.on_clicks.push(Rc::new(move || on_click.clone()()));
         self
     }
+}
 
-    pub fn into_node(self) -> Node<Ms> {
+impl<Ms> Component<Ms> for ButtonComponent<Ms> {
+    fn render(&self) -> Node<Ms> {
         let attrs = {
             let mut attrs = attrs! {};
 
@@ -84,7 +87,7 @@ impl<Ms> Component<Ms> {
         let mut button = button![css, attrs, self.label];
 
         if !self.disabled {
-            for on_click in self.on_clicks {
+            for on_click in self.on_clicks.iter().cloned() {
                 button.add_event_handler(ev(Ev::Click, move |_| on_click()));
             }
         }

--- a/examples/experimental_component/src/button.rs
+++ b/examples/experimental_component/src/button.rs
@@ -45,7 +45,7 @@ impl<Ms> ButtonComponent<Ms> {
 }
 
 impl<Ms> Component<Ms> for ButtonComponent<Ms> {
-    fn render(&self) -> Node<Ms> {
+    fn view(&self) -> Node<Ms> {
         let attrs = {
             let mut attrs = attrs! {};
 

--- a/examples/experimental_component/src/lib.rs
+++ b/examples/experimental_component/src/lib.rs
@@ -1,0 +1,86 @@
+use seed::{prelude::*, *};
+
+mod button;
+use button::Button;
+
+// ------ ------
+//     Init
+// ------ ------
+
+fn init(_: Url, _: &mut impl Orders<Msg>) -> Model {
+    Model::default()
+}
+
+// ------ ------
+//     Model
+// ------ ------
+
+type Model = i32;
+
+// ------ ------
+//    Update
+// ------ ------
+
+enum Msg {
+    Increment(i32),
+    Decrement(i32),
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
+    match msg {
+        Msg::Increment(d) => *model += d,
+        Msg::Decrement(d) => *model -= d,
+    }
+}
+
+// ------ ------
+//     View
+// ------ ------
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn view(model: &Model) -> Node<Msg> {
+    div![
+        style! {
+            St::Display => "flex"
+            St::AlignItems => "center",
+        },
+        comp![Button { label: "-100" },
+            disabled => true,
+            on_click => || Msg::Decrement(100),
+        ],
+        comp![Button { label: "-10" }, on_click => || Msg::Decrement(10)],
+        comp![Button { label: "-1" },
+            outlined => true,
+            on_click => || Msg::Decrement(1),
+        ],
+        div![style! { St::Margin => "0 1em" }, model],
+        comp![Button { label: "+1" },
+            outlined => true,
+            on_click => || Msg::Increment(1),
+        ],
+        comp![Button { label: "+10" }, on_click => || Msg::Increment(10)],
+        comp![Button { label: "+100" },
+              disabled => true,
+              on_click => || Msg::Increment(100),
+        ]
+    ]
+}
+
+#[macro_export]
+macro_rules! comp {
+    ($init:expr, $($opt_field:ident => $opt_val:expr),* $(,)?) => {
+        $init.into_component()
+            $( .$opt_field($opt_val) )*
+            .into_node()
+    };
+}
+
+// ------ ------
+//     Start
+// ------ ------
+
+#[wasm_bindgen(start)]
+pub fn start() {
+    App::start("app", init, update, view);
+}

--- a/examples/experimental_component/src/lib.rs
+++ b/examples/experimental_component/src/lib.rs
@@ -67,15 +67,6 @@ fn view(model: &Model) -> Node<Msg> {
     ]
 }
 
-#[macro_export]
-macro_rules! comp {
-    ($init:expr, $($opt_field:ident => $opt_val:expr),* $(,)?) => {
-        $init.into_component()
-            $( .$opt_field($opt_val) )*
-            .into_node()
-    };
-}
-
 // ------ ------
 //     Start
 // ------ ------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,8 +198,8 @@ pub mod prelude {
         // https://github.com/rust-lang-nursery/reference/blob/master/src/macros-by-example.md
         shortcuts::*,
         virtual_dom::{
-            el_key, el_ref::el_ref, AsAtValue, At, AtValue, CSSValue, El, ElRef, Ev, EventHandler,
-            IntoNodes, Node, St, Tag, ToClasses, UpdateEl, UpdateElForIterator, View,
+            el_key, el_ref::el_ref, AsAtValue, At, AtValue, CSSValue, Component, El, ElRef, Ev,
+            EventHandler, IntoNodes, Node, St, Tag, ToClasses, UpdateEl, UpdateElForIterator, View,
         },
     };
     pub use indexmap::IndexMap; // for attrs and style to work.

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -553,3 +553,17 @@ macro_rules! key_value_pairs {
         }
      };
 }
+
+#[cfg(feature = "experimental-component-api")]
+/// Instantiates and renders a `Component`
+///
+/// NOTE: This is an experimental API that requires the `experimental-component-api` feature.
+#[macro_export]
+macro_rules! comp {
+    ($init:expr, $($opt_field:ident => $opt_val:expr),* $(,)?) => {
+        $crate::virtual_dom::component::instantiate(
+            $init.into_component()
+                $( .$opt_field($opt_val) )*
+        )
+    };
+}

--- a/src/virtual_dom.rs
+++ b/src/virtual_dom.rs
@@ -1,4 +1,5 @@
 pub mod attrs;
+pub mod component;
 pub mod el_ref;
 pub mod event_handler_manager;
 pub mod mailbox;
@@ -11,6 +12,7 @@ pub mod values;
 pub mod view;
 
 pub use attrs::Attrs;
+pub use component::Component;
 pub use el_ref::{el_ref, ElRef, SharedNodeWs};
 pub use event_handler_manager::{EventHandler, EventHandlerManager, Listener};
 pub use mailbox::Mailbox;

--- a/src/virtual_dom/component.rs
+++ b/src/virtual_dom/component.rs
@@ -1,0 +1,17 @@
+use super::Node;
+
+pub trait Component<Ms> {
+    fn render(&self) -> Node<Ms>;
+}
+
+#[allow(clippy::needless_pass_by_value)]
+pub fn instantiate<Ms, C: Component<Ms>>(component: C) -> Node<Ms> {
+    // TODO: This is where we'd create a boundary node and a state container
+    // that can then either be passed to `render` to be populated, or capture
+    // hook calls indirectly like React does.
+    //
+    // The boundary node will own the state container and remember the component
+    // configuration, so that it can do a local re-render when triggered by a
+    // hook.
+    component.render()
+}

--- a/src/virtual_dom/component.rs
+++ b/src/virtual_dom/component.rs
@@ -1,7 +1,7 @@
 use super::Node;
 
 pub trait Component<Ms> {
-    fn render(&self) -> Node<Ms>;
+    fn view(&self) -> Node<Ms>;
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -13,5 +13,5 @@ pub fn instantiate<Ms, C: Component<Ms>>(component: C) -> Node<Ms> {
     // The boundary node will own the state container and remember the component
     // configuration, so that it can do a local re-render when triggered by a
     // hook.
-    component.render()
+    component.view()
 }


### PR DESCRIPTION
This is a proposal for a component API that offers:

- Labeled required properties, ensured to be present at compile-time
- Labeled optional properties
- Polymorphic for all properties
- A convenient consumer interface, through a stupidly simple macro that is very easy to understand

Perhaps more importantly though, the `comp!` macro provides the indirection necessary to intercept and create boundaries in the vdom tree, which enables state to be attached to nodes, local updates to be triggered, and paves the path towards implementing proper hooks.

I expect there to be some discussion around this, of course, but once we're reasonably confident in the design we could bring this in behind an experimental feature flag, and while it matures start looking into all the possible features it enables.