### PR TITLE
Add `At::Role`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+
 - Added helpers for wheel event: `wheel_ev` and `to_wheel_event`.
 - Use `wheel_ev` in `canvas` example to zoom rectangle with mouse scroll wheel.
 - [BREAKING] Base path changed from `Rc<Vec<String>>` to `Rc<[String]>`. It means also `Orders::clone_base_path` returns a slice.
@@ -12,10 +13,12 @@
 - Implemented `AsAtValue` for `Option<T>`
 - [BREAKING] Added argument `Option<&Namespace>` to functions `Node::from_html` and `El::from_html`.
 - Added macro `raw_svg!` (#589).
-- Added `browser::dom::Namespace` to `prelude`. 
+- Added `browser::dom::Namespace` to `prelude`.
 - Adapted to Rust 1.51.0.
+- Added `At::Role` variant.
 
 ## v0.8.0
+
 - [BREAKING] Rename `linear_gradient!` to `linearGradient!` for consistency with the other svg macros (same with `radial_gradient!` and `mesh_gradient!`) (#377).
 - Fixed `base_path` with a trailing slash parsing / handling.
 - Fixed `C` macro memory / WASM file size issue.
@@ -55,6 +58,7 @@
 - Added `Node::NoChange`.
 
 ## v0.7.0
+
 - [BREAKING] Custom elements are now patched in-place (#364). Use `el_key` to force reinitialize an element.
 - Added `el_key` method for adding keys to `El`s (#354).
 - Enabled all additional markdown [extensions](https://docs.rs/pulldown-cmark/latest/pulldown_cmark/struct.Options.html).
@@ -91,7 +95,7 @@
 - [deprecated] - `seed::browser::service::fetch` module is deprecated in favor of `seed::browser::fetch`.
 - Implemented `IntoNodes` for `Option<Node<Msg>>` and `Option<Vec<Node<Msg>>>`.
 - Implemented `UpdateEl` for `i64` and `u64`.
-- Reset properties `checked` and `value` on attribute remove (#405). 
+- Reset properties `checked` and `value` on attribute remove (#405).
 - Added examples `markdown`, `tea_component`, `subscribe`, `custom_elements`, `fetch`, `url`, `pages`, `pages_hash_routing`, `pages_keep_state`, `auth`, `bunnies` and `graphql` (#400).
 - Updated examples.
 - Removed examples `app_builder`, `orders`, `server_interaction`, `counter_advanced` and `mathjax`.
@@ -111,6 +115,7 @@
 - Added `#[derive(Debug)]` to `fetch::Response`
 
 ## v0.6.0
+
 - Implemented `UpdateEl` for `Filter` and `FilterMap`.
 - Added method `El::is_custom(&self)`.
 - Fixed custom elements patching (#325).
@@ -141,9 +146,10 @@
 - Adapted to Rust 1.41.0.
 
 ## v0.5.1
+
 - [BREAKING] `MessageMapper::map_message` changed to `MessageMapper::map_msg`.
 - [BREAKING] `fetch` and `storage` moved to `seed::browser::service::{fetch, storage}`,
-but reimported at the lib level. Ie: `seed::fetch`, and `seed::storage`.
+  but reimported at the lib level. Ie: `seed::fetch`, and `seed::storage`.
 - Added support for `Vec<Attr>` and `Vec<Style>` in view macros.
 - `App` included in `prelude`.
 - [BREAKING] Seed refactored to use `async/.await`. `fetch.rs` docs updated.
@@ -151,6 +157,7 @@ but reimported at the lib level. Ie: `seed::fetch`, and `seed::storage`.
 - Fixed a bug causing the docs not to build.
 
 ## v0.5.0
+
 - Added helper `seed::canvas()`, and `seed::canvas_context()` helper functions.
 - Fixed `Url` parsing (resolves issue with hash routing).
 - [BREAKING] `From<String> for Url` changed to `TryFrom<String> for Url`.
@@ -158,19 +165,20 @@ but reimported at the lib level. Ie: `seed::fetch`, and `seed::storage`.
 - Added method `orders.after_next_render(Option<RenderTimestampDelta>)` (#207).
 - Fixed a bug with back/forward routing to the landing page (#296).
 - Deprecated `Init` struct, replacing it with `BeforeMount` and `AfterMount` structs to
-better denote state before and after mounting the `App` occurs.
+  better denote state before and after mounting the `App` occurs.
 - Added a new function `builder` which replaces `build` as part of deprecating `Init`.
 - Added a new function `build_and_start` which replaces `finish` as part of deprecating `Init`.
 - Added `IntoInit`and `IntoAfterMount` traits. It is possible to use these
-in place of a closure or function to produce the corresponding `Init` and `AfterMount` structs.
+  in place of a closure or function to produce the corresponding `Init` and `AfterMount` structs.
 - Messages sent from `IntoAfterMount` will now be run after the routing message.
 - Added example `app_builder`.
 - `events::Listener` is included in `prelude`.
-- `()`s  have been replaced with structs - e.g. `GMs = ()` => `GMs = UndefinedGMs`.
+- `()`s have been replaced with structs - e.g. `GMs = ()` => `GMs = UndefinedGMs`.
 - `WindowEvents` alias changed to `WindowEventsFn` for consistency with other `*Fn`.
 - Commented builder and helper methods.
 
 ## v0.4.2
+
 - Added an `Init` struct, which can help with initial routing (Breaking)
 - The `routes` function now returns an `Option<Msg>` (Breaking)
 - Updated `Tag::from()` to accept more input types
@@ -187,17 +195,19 @@ in place of a closure or function to produce the corresponding `Init` and `After
 - Added `seed::html_document()` and `seed::cookies` convenience functions
 
 ## v0.4.1
+
 - Added more SVG `At` variants
 - Added the `St` enum, for style keys; similar to `At`
 - Improved ergonomics of `add_child`, `add_attr`, `add_class`,
-`add_style`, `replace_text`, and `add_text`, `Node` methods
+  `add_style`, `replace_text`, and `add_text`, `Node` methods
 
 ## v0.4.0
+
 - `ElContainer`, imported in prelude, renamed to `View`. (Breaking)
 - Internal refactor of `El`: Now wrapped in `Node`, along with
-`Empty` and `Text`. Creation macros return `Node(Element)`. (Breaking)
+  `Empty` and `Text`. Creation macros return `Node(Element)`. (Breaking)
 - Changed the way special attributes like `disabled`, `autofocus`, and
-`checked` are handled (Breaking)
+  `checked` are handled (Breaking)
 - `MessageMapper` now accepts closures
 - `Orders` is a trait now instead of a struct. (Breaking)
 - Significant changes to MessageMapper
@@ -206,32 +216,33 @@ in place of a closure or function to produce the corresponding `Init` and `After
 - Several minor bux fixes
 - Examples updated to reflect these changes
 - Improvements to Fetch API, especially regarding error handling
-and deserialization
+  and deserialization
 
 ## v0.3.7
+
 - `routes` now accepts `Url` instead of `&Url` (Breaking)
 - Improvements to fetch API
 - Added `raw!`, `md!`, and `plain!` macros that alias `El::from_html`, `El::from_markdown`,
-and `El::new_text` respectively
+  and `El::new_text` respectively
 - `Attrs!` and `Style!` macros can now use commas and whitespace as separators,
-in addition to semicolons
+  in addition to semicolons
 - Fixed typos in a few attributes (Breaking)
 - Fixed a bug where an HTML namespace was applied to raw html/markdown elements
 - New conditional syntax added in `class!` macro, similar to `Elm`'s `classList`
 - `Listener` now implements `MessageMapper`
 - `El methods` `add_child`, `add_style`, `add_attr`, and `set_text` now return the elements,
-allowing chaining
+  allowing chaining
 - Fixed a bug with `set_text`. Renamed to `replace_text`. Added `add_text`, which adds
-a text node, but doesn't remove existing ones. Added `add_class`. (Breaking)
-
+  a text node, but doesn't remove existing ones. Added `add_class`. (Breaking)
 
 ## v0.3.6
+
 - Fetch module and API heavily changed (breaking)
 - Added support for `request​Animation​Frame`, which improves render performance,
-especially for animations
+  especially for animations
 - Styles no longer implicitly add `px`. Added `unit!` macro in its place
 - `Map` can now be used directly in elements, without needing to annotate type and collect
-(ie for child `Elements`, and `Listener`s)
+  (ie for child `Elements`, and `Listener`s)
 - Significant changes to MessageMapper
 - Orders hs new methods, `clone_app` and `msg_mapper` that allow access to app instance.
 - Fixed a bug where `empty` elements at the top-level were rendering in the wrong order
@@ -239,84 +250,98 @@ especially for animations
 - Attributes and style now retain order
 
 ## v0.3.5
+
 - Fixed a bug where view functions returning `Vec<El>` weren't rendering properly
 - Fixed a typo with the `viewBox` attribute
 
 ## v0.3.4
+
 - The `update` fn now accepts a (new) `Orders` struct, and returns nothing. Renders occur implicitly,
-with the option to skip rendering, update with an additional message, or perform an asynchronous
-action. (Breaking)
+  with the option to skip rendering, update with an additional message, or perform an asynchronous
+  action. (Breaking)
 - `.mount()` now accepts elements. Deprecated `.mount_el()`
 - The `log` function and macro now support items which implement `Debug`
 - Removed deprecated `routing::push_path` function (breaking)
 
 ## v0.3.3
+
 - Added `seed::update` function, which allows custom events, and updates from JS
 
 ## v0.3.2
+
 - Top level view functions can now return `Vec<El<Ms>>`, `El<Ms>`, or something else implementing
-the new ElContainer trait
+  the new ElContainer trait
 
 ## v0.3.1
+
 - Top level view functions now return `Vec<El<Ms>>` instead of `El<Ms>`, mounted directly to
- the mount point. (Breaking)
+  the mount point. (Breaking)
 - `push_route()` can now accept a `Vec<&str>`, depreciating `push_path()`
 - Fixed a bug where window events couldn't be enabled on initialization
 
 ## v0.3.0
+
 - `update` function now takes a mutable ref of the model. (Breaking)
 - `Update` (update's return type) is now a struct. (Breaking)
 - Async, etc events are now handled through messages, instead of passing `App`
-through the view func. (Breaking)
+  through the view func. (Breaking)
 - Fixed some bugs with empty elements
 - Internal code cleanup
 - Added commented-out release command to example build files
 - Added more tests
 
 ## v0.2.10
+
 - Routing can be triggered by clicking any element containing a `Href` attribute
-with value as a relative link
+  with value as a relative link
 - Internal links no longer trigger a page refresh
 - Models no longer need to implement `Clone`
 - Fixed a bug introduced in 0.2.9 for `select` elements
 
 ## v0.2.9
+
 - Added a `RenderThen` option to `Update`, which allows chaining update messages
 - Added a `.model` method to `Update`, allowing for cleaner recursion in updates
 - Improved controlled-component (sync fields with model) logic
 
 ## v0.2.8
+
 - Reflowed `El::from_html` and `El::from_markdown` to return `Vec`s of `El`s, instead of wrapping
-them in a single span.
+  them in a single span.
 - Improved support for SVG and namespaces
 - Added `set_timeout` wrapper
 
 ## v0.2.7
+
 - Fixed a bug where `line!` macro interfered with builtin
 - Fixed a bug with routing search (ie `?`)
 
 ## v0.2.6
+
 - Fixed a bug where children would render out-of-order
 - Improved vdom diffing logic
 
 ## v0.2.5
+
 - Attributes and Events now can use `At` and `Ev` enums
 - Routing overhauled; modelled after react-reason. Cleaner syntax, and more flexible
 - Input, Textarea, and Select elements are now "controlled" - they always
-stay in sync with the model
+  stay in sync with the model
 - index.html file updated in examples and quickstart to use relative paths,
-which fixes landing-page routing
+  which fixes landing-page routing
 
 ## v0.2.4
+
 - Changed render func to use a new pattern (Breaking)
 - Default mount point added: \"app\" for element id
 - View func now takes a ref to the model instead of the model itself
 - Routing refactored; now works dynamically
 - Update function now returns an enum that returns Render or Skip,
-to allow conditional rendering (Breaking)
+  to allow conditional rendering (Breaking)
 - Elements can now store more than 1 text node
 
 ## V0.2.3
+
 - Fixed a bug where initially-empty text won't update
 - Added more tests
 - Exposed web_sys Document and Window in top level of Seed create, with .expect
@@ -324,10 +349,12 @@ to allow conditional rendering (Breaking)
 - Tests now work in Windows due to update in wasm-pack
 
 ## V0.2.2
+
 - Overhaul of fetch module
 - Added server-integration example
 
 ## V0.2.1
+
 - Added support for custom tags
 - Added `class!` and `id!` convenience macros for setting style
 

--- a/examples/auth/src/lib.rs
+++ b/examples/auth/src/lib.rs
@@ -174,7 +174,7 @@ fn view(model: &Model) -> impl IntoNodes<Msg> {
                     model
                         .user
                         .as_ref()
-                        .map(|user| user.username.to_owned())
+                        .map(|user| user.username.clone())
                         .unwrap_or_default()
                 ),
                 div![&model.secret_message],

--- a/examples/e2e_encryption/client/src/lib.rs
+++ b/examples/e2e_encryption/client/src/lib.rs
@@ -121,11 +121,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
                 .take()
                 .expect("registration state")
                 .finish(
-                    r2.expect("r2 bytes")
-                        .to_vec()
-                        .as_slice()
-                        .try_into()
-                        .expect("r2"),
+                    r2.expect("r2 bytes").as_slice().try_into().expect("r2"),
                     model.public_key.as_ref().expect("public key reference"),
                     &mut model.rng,
                 )
@@ -169,11 +165,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
                 .take()
                 .expect("registration state")
                 .finish(
-                    l2.expect("l2 bytes")
-                        .to_vec()
-                        .as_slice()
-                        .try_into()
-                        .expect("l2"),
+                    l2.expect("l2 bytes").as_slice().try_into().expect("l2"),
                     model.public_key.as_ref().expect("public key reference"),
                     &mut model.rng,
                 )

--- a/examples/i18n/src/i18n.rs
+++ b/examples/i18n/src/i18n.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::use_self)]
 use fluent::{FluentArgs, FluentBundle, FluentResource};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
 use unic_langid::LanguageIdentifier;

--- a/examples/service_worker/src/lib.rs
+++ b/examples/service_worker/src/lib.rs
@@ -71,8 +71,8 @@ struct WorkerData {
     subscription_saved: bool,
 }
 
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 struct PushSubscription {
     endpoint: String,
     expiration_time: Option<String>,

--- a/examples/websocket/src/client.rs
+++ b/examples/websocket/src/client.rs
@@ -174,7 +174,7 @@ fn view(model: &Model) -> Vec<Node<Msg>> {
                     ],
                     button![
                         ev(Ev::Click, {
-                            let message_text = model.input_text.to_owned();
+                            let message_text = model.input_text.clone();
                             move |_| Msg::SendMessage(shared::ClientMessage { text: message_text })
                         }),
                         "Send"
@@ -192,7 +192,7 @@ fn view(model: &Model) -> Vec<Node<Msg>> {
                     ],
                     button![
                         ev(Ev::Click, {
-                            let message_text = model.input_binary.to_owned();
+                            let message_text = model.input_binary.clone();
                             move |_| {
                                 Msg::SendBinaryMessage(shared::ClientMessage { text: message_text })
                             }

--- a/src/browser/web_socket/message.rs
+++ b/src/browser/web_socket/message.rs
@@ -48,7 +48,7 @@ impl WebSocketMessage {
         }
 
         if let Some(blob) = self.data.dyn_ref::<web_sys::Blob>() {
-            let blob = gloo_file::Blob::from(blob.to_owned());
+            let blob = gloo_file::Blob::from(blob.clone());
             let bytes = gloo_file::futures::read_as_bytes(&blob)
                 .await
                 .map_err(WebSocketError::FileReaderError)?;

--- a/src/dom_entity_names/attributes/attribute_names.rs
+++ b/src/dom_entity_names/attributes/attribute_names.rs
@@ -35,7 +35,7 @@ make_attrs! {
     OnToggle => "ontoggle", OnUnload => "onunload", OnVolumeChange => "onvolumechange", OnWaiting => "onwaiting",
     OnWheel => "onwheel", Open => "open", Optimum => "optimum", Pattern => "pattern", Placeholder => "placeholder",
     Poster => "poster", Preload => "preload", ReadOnly => "readonly", Rel => "rel", Required => "required",
-    Reversed => "reversed", Rows => "rows", RowSpan => "rowspan", Sandbox => "sandbox", Scope => "scope",
+    Role => "role", Reversed => "reversed", Rows => "rows", RowSpan => "rowspan", Sandbox => "sandbox", Scope => "scope",
     Selected => "selected", Shape => "shape", Size => "size", Span => "span", SpellCheck => "spellcheck",
     Src => "src", SrcDoc => "srcdoc", SrcLang => "srclang", SrcSet => "srcset", Start => "start",
     Step => "step", Style => "style", TabIndex => "tabindex", Target => "target", Title => "title",


### PR DESCRIPTION
This PR adds a `Role` variant for the giant `At` enum, so that the `role` attribute can be used like so:

```html
<nav role="navigation"></nav>
```
