### PR TITLE
fix(vdom): don't update value property if it hasn't changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Implemented `FromIterator<(impl Into<Cow<'a, str>>, impl Into<Cow<'a, str>>)>` for `Headers`.
 - Derived `Eq` and `PartialEq` for `Header`.
 - Added `Header::name()` and `Header::value()`.
+- Fixed an issue in vdom where inputs with invalid contents being cleared on Firefox
 
 ## v0.8.0
 

--- a/src/browser/util.rs
+++ b/src/browser/util.rs
@@ -213,6 +213,11 @@ fn set_html_input_element_value(
     input: &web_sys::HtmlInputElement,
     value: &str,
 ) -> Result<(), Cow<'static, str>> {
+    // Don't update if value hasn't changed
+    if value == input.value() {
+        return Ok(());
+    }
+
     // In some cases we need to set selection manually because
     // otherwise the cursor would jump at the end on some platforms.
 


### PR DESCRIPTION
This addresses a problem we encountered with number inputs in Firefox, where `HtmlInputElement.value` will only return a valid number. or the empty string, instead of the actual contents of the input. This causes two problems in typical use, 1) it clears the input if the user enters an invalid character, and 2) it's not possible to enter the decimal point key-by-key since entering e.g. `12.` will have `value` return `12`, thereby deleting the decimal point.

The workaround implemented here is to simply not update the DOM if `value` seems unchanged. In the problematic case above it has, of course, and this will cause the input to become out of sync with the model. But the root of the problem is that it already is, and there seems to be no way to get the actual contents of the input. So it seems to me that the lesser evil is to accept that instead of forcing synchronization by clearing the input.

Note that [this is also what Elm does](https://github.com/elm/virtual-dom/blob/5a5bcf48720bc7d53461b3cd42a9f19f119c5503/src/Elm/Kernel/VirtualDom.js#L496), and has done for years. It was implemented five years ago to address [a different issue](https://github.com/elm/html/issues/4) (that seems to be addressed with significantly more complex logic further down in this function, which we might now remove?). It therefore feels like a relatively safe change, or at least one that has been thoroughly tested in real world scenarios.

There is one known problem with this, however, also only in Firefox. If the input has invalid contents it's no longer possible to clear it by programmatically setting `value` to the empty string, since it will already appear empty and therefore not actually do anything. [This is still unresolved in Elm](https://github.com/elm/html/issues/205).

Another option to address this is to implement a more general opt-in mechanism for property-setting, but that seems like a much more invasive change. Although if we look to Elm again, it seems like [most attributes are actually implemented using the equivalent property instead of the attribute](https://github.com/elm/html/blob/1.0.0/src/Html/Attributes.elm).