### PR TITLE
Basic FormData interface for multipart support in fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Derived `Eq` and `PartialEq` for `Header`.
 - Added `Header::name()` and `Header::value()`.
 - Fixed an issue in vdom where inputs with invalid contents being cleared on Firefox
+- Added `fetch::form_data::FormData` and `Request.form_data`
 
 ## v0.8.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ features = [
     "HtmlTextAreaElement",
     "HtmlSelectElement",
     "HtmlButtonElement",
+    "HtmlFormElement",
     "Location",
     "MessageEvent",
     "MouseEvent",

--- a/src/browser/fetch.rs
+++ b/src/browser/fetch.rs
@@ -32,12 +32,14 @@ use crate::util::window;
 use std::convert::TryInto;
 use wasm_bindgen_futures::JsFuture;
 
+pub mod form_data;
 pub mod header;
 mod method;
 mod request;
 mod response;
 mod status;
 
+pub use form_data::FormData;
 pub use header::{Header, Headers};
 pub use method::*;
 pub use request::*;

--- a/src/browser/fetch/form_data.rs
+++ b/src/browser/fetch/form_data.rs
@@ -1,3 +1,24 @@
+//! Provides a simplified (and incomplete) interface to the `FormData` Web API,
+//! in order to facilitate the creation of multipart request bodies for seed's
+//! Fetch API.
+//!
+//! ## Example
+//!
+//! ```
+//! let form_data = FormData::new()
+//!     .with_str("first-name", "Bob")
+//!     .with_str("last-name", "Jones");
+//!
+//! Request::new("/api/")
+//!     .method(Method::Post)
+//!     .form_data(form_data)
+//!     .fetch()
+//!
+//! ```
+//!
+//! See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/FormData) for
+//! details on the behavior of the underlying API.
+
 use crate::fetch::{FetchError, Result};
 use serde::Serialize;
 use wasm_bindgen::JsValue;
@@ -5,25 +26,38 @@ use wasm_bindgen::JsValue;
 pub struct FormData(web_sys::FormData);
 
 impl FormData {
+    /// Creates a new empty `FormData` object.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Appends a blob value.
+    #[allow(clippy::missing_panics_doc)]
+    pub fn append_blob(&mut self, name: &str, blob: &web_sys::Blob) {
         self.0.append_with_blob(name, blob).unwrap();
     }
+    /// The builder-style variant of `append_blob`.
     pub fn with_blob(mut self, name: &str, blob: &web_sys::Blob) -> Self {
         self.append_blob(name, blob);
         self
     }
 
+    /// Appends a string value.
+    #[allow(clippy::missing_panics_doc)]
     pub fn append_str(&mut self, name: &str, str: &str) {
         self.0.append_with_str(name, str).unwrap();
     }
+    /// The builder-style variant of `append_str`,
     pub fn with_str(mut self, name: &str, str: &str) -> Self {
         self.append_str(name, str);
         self
     }
 
+    /// Appends a json value.
+    ///
+    /// ## Errors
+    /// Will return `Err` if serialization fails.
+    #[allow(clippy::missing_panics_doc)]
     pub fn append_json<T>(&mut self, name: &str, data: &T) -> Result<()>
     where
         T: Serialize + ?Sized,
@@ -32,6 +66,10 @@ impl FormData {
         self.0.append_with_str(name, &str).unwrap();
         Ok(())
     }
+    /// The builder-style variant of `append_json`
+    ///
+    /// ## Errors
+    /// Will return `Err` if serialization fails.
     pub fn with_json<T>(mut self, name: &str, data: &T) -> Result<Self>
     where
         T: Serialize + ?Sized,

--- a/src/browser/fetch/form_data.rs
+++ b/src/browser/fetch/form_data.rs
@@ -1,0 +1,68 @@
+use crate::fetch::{FetchError, Result};
+use serde::Serialize;
+use wasm_bindgen::JsValue;
+
+pub struct FormData(web_sys::FormData);
+
+impl FormData {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+        self.0.append_with_blob(name, blob).unwrap();
+    }
+    pub fn with_blob(mut self, name: &str, blob: &web_sys::Blob) -> Self {
+        self.append_blob(name, blob);
+        self
+    }
+
+    pub fn append_str(&mut self, name: &str, str: &str) {
+        self.0.append_with_str(name, str).unwrap();
+    }
+    pub fn with_str(mut self, name: &str, str: &str) -> Self {
+        self.append_str(name, str);
+        self
+    }
+
+    pub fn append_json<T>(&mut self, name: &str, data: &T) -> Result<()>
+    where
+        T: Serialize + ?Sized,
+    {
+        let str = serde_json::to_string(data).map_err(FetchError::SerdeError)?;
+        self.0.append_with_str(name, &str).unwrap();
+        Ok(())
+    }
+    pub fn with_json<T>(mut self, name: &str, data: &T) -> Result<Self>
+    where
+        T: Serialize + ?Sized,
+    {
+        self.append_json(name, data)?;
+        Ok(self)
+    }
+}
+
+impl Default for FormData {
+    #[allow(clippy::missing_panics_doc)]
+    fn default() -> Self {
+        FormData(web_sys::FormData::new().unwrap())
+    }
+}
+
+impl From<web_sys::FormData> for FormData {
+    fn from(form_data: web_sys::FormData) -> Self {
+        FormData(form_data)
+    }
+}
+
+#[allow(clippy::fallible_impl_from)]
+impl From<&web_sys::HtmlFormElement> for FormData {
+    fn from(form: &web_sys::HtmlFormElement) -> Self {
+        FormData(web_sys::FormData::new_with_form(form).unwrap())
+    }
+}
+
+impl From<FormData> for JsValue {
+    fn from(form_data: FormData) -> JsValue {
+        JsValue::from(form_data.0)
+    }
+}

--- a/src/browser/fetch/request.rs
+++ b/src/browser/fetch/request.rs
@@ -1,5 +1,6 @@
 //! The Request of the Fetch API.
 
+use super::form_data::FormData;
 use super::{fetch, FetchError, Header, Headers, Method, Response, Result};
 use crate::browser::Url;
 use gloo_timers::callback::Timeout;
@@ -105,6 +106,13 @@ impl<'a> Request<'a> {
     pub fn bytes(mut self, bytes: impl AsRef<[u8]>) -> Self {
         self.body = Some(Uint8Array::from(bytes.as_ref()).into());
         self.header(Header::content_type("application/octet-stream"))
+    }
+
+    /// Set request body to the provided form data object.
+    /// It will also set `Content-Type` header to `multipart/form-data`.
+    pub fn form_data(mut self, form_data: FormData) -> Self {
+        self.body = Some(form_data.into());
+        self
     }
 
     /// Set request mode.


### PR DESCRIPTION
Provides a very simplified and incomplete interface to the `FormData` Web API in order to support multipart requests for fetch with some convenience.