### PR TITLE
example: sl_inpuit added to custom_elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@
 - Implemented `FromIterator<(impl Into<Cow<'a, str>>, impl Into<Cow<'a, str>>)>` for `Headers`.
 - Derived `Eq` and `PartialEq` for `Header`.
 - Added `Header::name()` and `Header::value()`.
-- Fixed an issue in vdom where inputs with invalid contents being cleared on Firefox
-- Added `fetch::form_data::FormData` and `Request.form_data`
+- Fixed an issue in vdom where inputs with invalid contents being cleared on Firefox.
+- Added `fetch::form_data::FormData` and `Request.form_data`.
+- Added `sl_input` to the `custom_elements` example.
 
 ## v0.8.0
 

--- a/examples/custom_elements/index.html
+++ b/examples/custom_elements/index.html
@@ -22,6 +22,9 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script type="module" src="/public/math-tex.js"></script>
 
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.43/dist/themes/base.min.css">
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.43/dist/shoelace.min.js"></script>
+
     <script type="module">
         import init from '/pkg/package.js';
         init('/pkg/package_bg.wasm');

--- a/examples/custom_elements/src/lib.rs
+++ b/examples/custom_elements/src/lib.rs
@@ -4,6 +4,7 @@ mod checkbox_tristate;
 mod code_block;
 mod feather_icon;
 mod math_tex;
+mod sl_input;
 
 // ------ ------
 //     Init
@@ -20,6 +21,7 @@ fn init(_: Url, _: &mut impl Orders<Msg>) -> Model {
 #[derive(Default)]
 struct Model {
     pub checkbox_state: checkbox_tristate::State,
+    input_value: String,
 }
 
 // ------ ------
@@ -28,6 +30,7 @@ struct Model {
 
 enum Msg {
     RotateCheckboxState(String),
+    InputChanged(String),
 }
 
 #[allow(clippy::needless_pass_by_value)]
@@ -37,6 +40,9 @@ fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
             if name == "checkbox-tristate" {
                 model.checkbox_state = model.checkbox_state.next()
             }
+        }
+        Msg::InputChanged(value) => {
+            model.input_value = value;
         }
     }
 }
@@ -70,6 +76,12 @@ fn view(model: &Model) -> impl IntoNodes<Msg> {
         div![
             "math-tex",
             math_tex::view(r"\mathbb{1} = \sum_i \lvert i \rangle \langle i \rvert"),
+        ],
+        hr![],
+        div![
+            "sl-input",
+            sl_input![sl_input::on_input(Msg::InputChanged)],
+            &model.input_value,
         ],
     ]
 }

--- a/examples/custom_elements/src/sl_input.rs
+++ b/examples/custom_elements/src/sl_input.rs
@@ -1,0 +1,25 @@
+use js_sys::Reflect;
+use seed::prelude::*;
+
+#[macro_export]
+macro_rules! sl_input {
+    ( $($part:expr),* $(,)? ) => {
+        {
+            custom![
+                Tag::from("sl-input"),
+                $( $part )*
+            ]
+        }
+    };
+}
+
+pub fn on_input<Ms: 'static>(
+    handler: impl FnOnce(String) -> Ms + Clone + 'static,
+) -> EventHandler<Ms> {
+    ev(Ev::from("sl-input"), |event| {
+        let event_target = event.target().unwrap();
+        let property_name = JsValue::from("value");
+        let value = Reflect::get(&event_target, &property_name).unwrap();
+        handler(value.as_string().unwrap())
+    })
+}


### PR DESCRIPTION
I can imagine we can implement a helper macro like `make_custom_element!("sl-input")` later. Maybe also some `Reflect` helpers would be nice.