### PR TITLE
fix(fetch): changed Request.body to take its argument by reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed an issue in vdom where inputs with invalid contents being cleared on Firefox.
 - Added `fetch::form_data::FormData` and `Request.form_data`.
 - Added `sl_input` to the `custom_elements` example.
+- [BREAKING] Changed `Request.body` to take its argument by reference
 
 ## v0.8.0
 

--- a/examples/server_integration/client/src/example_e.rs
+++ b/examples/server_integration/client/src/example_e.rs
@@ -116,7 +116,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
 async fn send_request(form: FormData) -> fetch::Result<String> {
     Request::new(get_request_url())
         .method(fetch::Method::Post)
-        .body(form.into())
+        .body(&form.into())
         .fetch()
         .await?
         .text()


### PR DESCRIPTION
Since `RequestInit::body` actually takes a `&JsValue`, we can have `Request::body` take a reference too, and store it in a `Cow` internally, which helps with sharing data in interop-heavy code that assumes JS idioms and GC'd values.

This is a breaking change, but a minor one I think. Alternatively we could add a separate `body_ref` function instead.