### PR TITLE
Intersection Observer example (again)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ members = [
     "examples/el_key",
     "examples/graphql",
     "examples/i18n",
+    "examples/intersection_observer",
     "examples/markdown",
     "examples/fetch",
     "examples/no_change",

--- a/examples/intersection_observer/Cargo.toml
+++ b/examples/intersection_observer/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "intersection_observer"
+version = "0.1.0"
+authors = ["allan2"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.18"
+
+[dependencies]
+seed = { path = "../../" }
+js-sys = { version = "0.3.51" }
+
+[dependencies.web-sys]
+version = "0.3.51"
+features = [
+    "IntersectionObserver",
+    "IntersectionObserverInit",
+    "IntersectionObserverEntry",
+]
+
+[profile.release]
+lto = true
+opt-level = 'z'
+codegen-units = 1
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-Os']

--- a/examples/intersection_observer/Cargo.toml
+++ b/examples/intersection_observer/Cargo.toml
@@ -21,11 +21,3 @@ features = [
     "IntersectionObserverInit",
     "IntersectionObserverEntry",
 ]
-
-[profile.release]
-lto = true
-opt-level = 'z'
-codegen-units = 1
-
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-Os']

--- a/examples/intersection_observer/Makefile.toml
+++ b/examples/intersection_observer/Makefile.toml
@@ -1,0 +1,27 @@
+extend = "../../Makefile.toml"
+
+# ---- BUILD ----
+
+[tasks.build]
+alias = "default_build"
+
+[tasks.build_release]
+alias = "default_build_release"
+
+# ---- START ----
+
+[tasks.start]
+alias = "default_start"
+
+[tasks.start_release]
+alias = "default_start_release"
+
+# ---- TEST ----
+
+[tasks.test_firefox]
+alias = "default_test_firefox"
+
+# ---- LINT ----
+
+[tasks.clippy]
+alias = "default_clippy"

--- a/examples/intersection_observer/README.md
+++ b/examples/intersection_observer/README.md
@@ -1,0 +1,18 @@
+# Intersection Observer Example
+
+This example uses the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) through web-sys.
+
+The intersection observer is created. We tell it to watch the red box by giving the element reference to the observer.
+When the red box is entirely in view, the label "Is completely visible" will display a value of `true`.
+
+To run, use the following commands from the `intersection_observer` directory.
+
+Using `trunk`:
+```
+trunk serve
+```
+
+Using `cargo-make`:
+```
+cargo make start
+```

--- a/examples/intersection_observer/index.html
+++ b/examples/intersection_observer/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="modulepreload" href="/pkg/package.js" as="script" type="text/javascript">
+    <link rel="preload" href="/pkg/package_bg.wasm" as="fetch" type="application/wasm" crossorigin="anonymous">
+    <title>Test</title>
+    <link data-trunk rel="css" href="public/index.css" />
+</head>
+
+<body>
+    <div id="app"></div>
+    <script type="module">
+        import init from '/pkg/package.js';
+        init('/pkg/package_bg.wasm');
+    </script>
+</body>
+</html>

--- a/examples/intersection_observer/public/index.css
+++ b/examples/intersection_observer/public/index.css
@@ -1,0 +1,3 @@
+body {
+	margin: 0;
+}

--- a/examples/intersection_observer/src/lib.rs
+++ b/examples/intersection_observer/src/lib.rs
@@ -1,0 +1,124 @@
+use seed::{prelude::*, *};
+use web_sys::{IntersectionObserver, IntersectionObserverEntry, IntersectionObserverInit};
+
+fn init(_: Url, orders: &mut impl Orders<Msg>) -> Model {
+    orders.after_next_render(|_| Msg::SetupObserver);
+    Model {
+        box_container: ElRef::new(),
+        red_box: ElRef::new(),
+        observer: None,
+        observer_callback: None,
+        observer_entries: None,
+    }
+}
+
+struct Model {
+    box_container: ElRef<web_sys::Element>,
+    red_box: ElRef<web_sys::Element>,
+    observer: Option<IntersectionObserver>,
+    observer_callback: Option<Closure<dyn Fn(Vec<JsValue>)>>,
+    observer_entries: Option<Vec<IntersectionObserverEntry>>,
+}
+
+enum Msg {
+    SetupObserver,
+    Observed(Vec<IntersectionObserverEntry>),
+}
+
+fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
+    match msg {
+        Msg::Observed(entries) => {
+            model.observer_entries = Some(entries);
+        }
+        Msg::SetupObserver => {
+            orders.skip();
+
+            // ---- observer callback ----
+            let sender = orders.msg_sender();
+            let callback = move |entries: Vec<JsValue>| {
+                let entries = entries
+                    .into_iter()
+                    .map(IntersectionObserverEntry::from)
+                    .collect();
+                sender(Some(Msg::Observed(entries)));
+            };
+            let callback = Closure::wrap(Box::new(callback) as Box<dyn Fn(Vec<JsValue>)>);
+
+            // ---- observer options ----
+            let mut options = IntersectionObserverInit::new();
+            options.threshold(&JsValue::from(1));
+            // ---- observer ----
+            let observer =
+                IntersectionObserver::new_with_options(callback.as_ref().unchecked_ref(), &options)
+                    .unwrap();
+
+            observer.observe(&model.red_box.get().unwrap());
+
+            // Note: Drop `observer` is not enough. We have to call `observer.disconnect()`.
+            model.observer = Some(observer);
+            model.observer_callback = Some(callback);
+        }
+    }
+}
+
+fn view(model: &Model) -> Node<Msg> {
+    div![
+        view_info(model.observer_entries.as_ref()),
+        view_box_container(model),
+    ]
+}
+
+fn view_info(observer_entries: Option<&Vec<IntersectionObserverEntry>>) -> Option<Node<Msg>> {
+    let entry = observer_entries?.first()?;
+    Some(div![
+        style! {
+            St::Position => "fixed",
+            St::Background => "white",
+        },
+        div![format!("Target: {}", entry.target().id()),],
+        div![format!(
+            "Is completely visible: {}",
+            entry.is_intersecting()
+        )]
+    ])
+}
+
+fn view_box_container(model: &Model) -> Node<Msg> {
+    div![
+        // don't allow VDOM to reuse the `div` for other elements (it would break observing)
+        el_key(&"box-container"),
+        el_ref(&model.box_container),
+        style! {
+            St::Height => vh(100),
+        },
+        view_blue_box(),
+        view_red_box(&model.red_box),
+        view_blue_box(),
+    ]
+}
+
+fn view_red_box(red_box: &ElRef<web_sys::Element>) -> Node<Msg> {
+    div![
+        el_ref(red_box),
+        id!("red-box"),
+        style! {
+            St::Height => vh(70),
+            St::Background => "red",
+        }
+    ]
+}
+
+fn view_blue_box() -> Node<Msg> {
+    div![
+        C!["blue-box"],
+        style! {
+            St::Height => vh(100),
+            St::Background => "blue",
+        }
+    ]
+}
+
+#[wasm_bindgen(start)]
+pub fn start() {
+    App::start("app", init, update, view);
+}


### PR DESCRIPTION
- added Makefile and works with `cargo-make`
- added newline to the end of `index.html` (it's not displayed on GitHub but you can see it when you click "Edit file")
- removed printing with Debug where not needed
- formatted with `rustfmt` (forgot last time!)

This PR is for Issue #612 and replaces PR #613.
The reason for tis new PR is me being bad at `git`. I deleted my fork and re-forked.

I wasn't sure how to get the CSS to work with both `trunk` and `cargo-make`.