### PR TITLE
Return response with details from the server on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Removed internal `serde_json` usage in favour of `serde-wasm-bindgen`. This reduces final binary size for downstream users.
 - [BREAKING] Removed the deprecated `browser::service::fetch` module.
 - Element macros like `div!` can now contain `Iterator`s inside of `Option` values. Previously only one or the other was possible.
+- Add method to return detailed error response from server with `FetchError`.
 
 ## v0.8.0
 

--- a/src/browser/fetch/response.rs
+++ b/src/browser/fetch/response.rs
@@ -101,6 +101,26 @@ impl Response {
         }
     }
 
+    /// Check that response status is ok (2xx), in case of error return a tuple of error and Option<String>
+    /// with the error response from a server.
+    ///
+    /// ```rust
+    /// fetch(url).await?.check_detailed_status()?
+    /// ```
+    ///
+    /// # Errors
+    /// Returns a tuple of `FetchError` and `Option<String>` with error details if status isn't 2xx.
+    pub async fn check_detailed_status(
+        self,
+    ) -> std::result::Result<Self, (FetchError, Option<String>)> {
+        let status = self.status();
+        if status.is_ok() {
+            Ok(self)
+        } else {
+            Err((FetchError::StatusError(status), self.text().await.ok()))
+        }
+    }
+
     /// Get underlying `web_sys::Response`.
     ///
     /// This is an escape path if current API can't handle your needs.


### PR DESCRIPTION
Resolves #616

This PR introduces a new enum variant for `FetchError` that contains the response status together with the JSON response returned from the server.

Initially, I wanted to change the `check_status()` method to try to return the new variant first, and in case of JSON parse error just return the regular `StatusError`, but it would require changing the method to `async` which would be a breaking change. Therefore I decided to add another method.

Here's how it looks when you `log!()` such error:  
```
DetailedStatusError(
    Status {
        code: 500,
        text: "Internal Server Error",
        category: ServerError,
    },
    Object({
        "details": String("cannot connect to the database",),
    }),
)
```