### PR TITLE
Allow passing owned values to Request.body (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,12 @@
 - Fixed an issue in vdom where inputs with invalid contents being cleared on Firefox.
 - Added `fetch::form_data::FormData` and `Request.form_data`.
 - Added `sl_input` to the `custom_elements` example.
-- [BREAKING] Changed `Request.body` to take its argument by reference.
 - Adapted to Rust 1.53.0.
 - Removed internal `serde_json` usage in favour of `serde-wasm-bindgen`. This reduces final binary size for downstream users.
 - [BREAKING] Removed the deprecated `browser::service::fetch` module.
 - Element macros like `div!` can now contain `Iterator`s inside of `Option` values. Previously only one or the other was possible.
 - Add method to return detailed error response from server with `FetchError`.
+- Added `Request.body_ref` to take the body by reference.
 
 ## v0.8.0
 

--- a/examples/server_integration/client/src/example_e.rs
+++ b/examples/server_integration/client/src/example_e.rs
@@ -116,7 +116,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
 async fn send_request(form: FormData) -> fetch::Result<String> {
     Request::new(get_request_url())
         .method(fetch::Method::Post)
-        .body(&form.into())
+        .body(JsValue::from(form))
         .fetch()
         .await?
         .text()

--- a/examples/server_integration/client/src/example_e.rs
+++ b/examples/server_integration/client/src/example_e.rs
@@ -221,7 +221,7 @@ pub fn view(model: &Model, intro: impl FnOnce(&str, &str) -> Vec<Node<Msg>>) -> 
         ),
         button![
             style! {
-                "padding" => format!{"{} {}", px(2), px(12)},
+                "padding" => format!("{} {}", px(2), px(12)),
                 "background-color" => if btn_enabled { CSSValue::from("aquamarine") } else { CSSValue::Ignored },
             },
             attrs! {At::Disabled => not(btn_enabled).as_at_value()},

--- a/src/browser/fetch/request.rs
+++ b/src/browser/fetch/request.rs
@@ -83,6 +83,25 @@ impl<'a> Request<'a> {
         self
     }
 
+    /// Set request body to provided `JsValue` by reference. Consider using
+    /// `json`, `text` or `bytes` methods instead.
+    ///
+    /// ## Panics
+    /// This method will panic when request method is GET or HEAD.
+    pub fn body_ref(mut self, body: &'a JsValue) -> Self {
+        self.body = Some(Cow::Borrowed(body));
+
+        #[cfg(debug_assertions)]
+        match self.method {
+            Method::Get | Method::Head => {
+                error!("GET and HEAD requests shoudn't have a body");
+            }
+            _ => {}
+        }
+
+        self
+    }
+
     /// Set request body by JSON encoding provided data.
     /// It will also set `Content-Type` header to `application/json; charset=utf-8`.
     ///

--- a/src/browser/fetch/request.rs
+++ b/src/browser/fetch/request.rs
@@ -64,12 +64,13 @@ impl<'a> Request<'a> {
         self
     }
 
-    /// Set request body to provided `JsValue`. Consider using `json`, `text`, or `bytes` methods instead.
+    /// Set request body to provided `JsValue`. Consider using `json`, `text`
+    /// or `bytes` methods instead.
     ///
     /// ## Panics
     /// This method will panic when request method is GET or HEAD.
-    pub fn body(mut self, body: &'a JsValue) -> Self {
-        self.body = Some(Cow::Borrowed(body));
+    pub fn body(mut self, body: JsValue) -> Self {
+        self.body = Some(Cow::Owned(body));
 
         #[cfg(debug_assertions)]
         match self.method {


### PR DESCRIPTION
Seems it's sometimes convenient to be able to pass owned values as well, so this reverts the earlier change from #606 and adds `body_red` instead. It would be nice if it was possible to have `body` take an `impl Into<Cow...>`, but unfortunately it doesn't seem to be. At least not without some convoluted proxy type implementing `From` specifically for `JsValue` and `&JsValue` as anything meoe generic would have the `impl`s conflict.

Also, I guess this is an unbreaking change, in a sense.