### PR TITLE
feat(virtual-dom): blanket impl of IntoNodes for Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [BREAKING] Removed the deprecated `browser::service::fetch` module.
 - Element macros like `div!` can now contain `Iterator`s inside of `Option` values. Previously only one or the other was possible.
 - Add method to return detailed error response from server with `FetchError`.
+- [BREAKING] Added blanket `impl<Ms, T: IntoNodes<Ms>> IntoNode<Ms> for Option<T>`. This might conflict with local `impl`s of `IntoNodes`, but should make those unnecessary and safe to remove.
 
 ## v0.8.0
 

--- a/src/virtual_dom/node/into_nodes.rs
+++ b/src/virtual_dom/node/into_nodes.rs
@@ -14,7 +14,7 @@ impl<Ms> IntoNodes<Ms> for Node<Ms> {
     }
 }
 
-impl<Ms> IntoNodes<Ms> for Option<Node<Ms>> {
+impl<Ms, T: IntoNodes<Ms>> IntoNodes<Ms> for Option<T> {
     fn into_nodes(self) -> Vec<Node<Ms>> {
         self.map(IntoNodes::into_nodes).unwrap_or_default()
     }
@@ -23,11 +23,5 @@ impl<Ms> IntoNodes<Ms> for Option<Node<Ms>> {
 impl<Ms> IntoNodes<Ms> for Vec<Node<Ms>> {
     fn into_nodes(self) -> Vec<Node<Ms>> {
         self
-    }
-}
-
-impl<Ms> IntoNodes<Ms> for Option<Vec<Node<Ms>>> {
-    fn into_nodes(self) -> Vec<Node<Ms>> {
-        self.unwrap_or_default()
     }
 }


### PR DESCRIPTION
This replaces the specific `impl`s of `IntoNodes` for `Option<Node<Ms>>` and `Option<Vec<Node<Ms>>` with a blanket implementation for `Option<T> where T: IntoNodes`. This isn't just for convenience, as it also solves the problem of not being able to implement `IntoNodes<Ms>` for `Option<T>` if `T` does not include `Ms` as a type parameter, since that violates the orphan rule (`E0210``).