### PR TITLE
feat(virtual_dom): add `on_insert` event triggered on DOM insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Element macros like `div!` can now contain `Iterator`s inside of `Option` values. Previously only one or the other was possible.
 - Add method to return detailed error response from server with `FetchError`.
 - [BREAKING] Added blanket `impl<Ms, T: IntoNodes<Ms>> IntoNode<Ms> for Option<T>`. This might conflict with local `impl`s of `IntoNodes`, but should make those unnecessary and safe to remove.
+- Added `on_insert` event on elements, triggered when they are inserted into the DOM.
 
 ## v0.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "on_insert"
+version = "0.1.0"
+dependencies = [
+ "seed",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ members = [
     "examples/markdown",
     "examples/fetch",
     "examples/no_change",
+    "examples/on_insert",
     "examples/pages",
     "examples/pages_hash_routing",
     "examples/pages_keep_state",

--- a/examples/on_insert/Cargo.toml
+++ b/examples/on_insert/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "on_insert"
+version = "0.1.0"
+authors = ["Glenn Slotte <glenn@slotte.net>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+seed = {path = "../../"}

--- a/examples/on_insert/Makefile.toml
+++ b/examples/on_insert/Makefile.toml
@@ -1,0 +1,27 @@
+extend = "../../Makefile.toml"
+
+# ---- BUILD ----
+
+[tasks.build]
+alias = "default_build"
+
+[tasks.build_release]
+alias = "default_build_release"
+
+# ---- START ----
+
+[tasks.start]
+alias = "default_start"
+
+[tasks.start_release]
+alias = "default_start_release"
+
+# ---- TEST ----
+
+[tasks.test_firefox]
+alias = "default_test_firefox"
+
+# ---- LINT ----
+
+[tasks.clippy]
+alias = "default_clippy"

--- a/examples/on_insert/README.md
+++ b/examples/on_insert/README.md
@@ -1,0 +1,9 @@
+## on_insert example
+
+Demonstrates the use of `on_insert` to autofocus input elements on DOM insertion.
+
+```bash
+cargo make start
+```
+
+Open [127.0.0.1:8000](http://127.0.0.1:8000) in your browser.

--- a/examples/on_insert/index.html
+++ b/examples/on_insert/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <title>on_insert example</title>
+</head>
+
+<body style="margin: 0; overflow: hidden;">
+  <section id="app"></section>
+  <script type="module">
+    import init from '/pkg/package.js';
+    init('/pkg/package_bg.wasm');
+  </script>
+</body>
+
+</html>

--- a/examples/on_insert/src/lib.rs
+++ b/examples/on_insert/src/lib.rs
@@ -1,0 +1,75 @@
+#![allow(clippy::needless_pass_by_value)]
+
+use seed::{prelude::*, *};
+
+// ------ ------
+//     Init
+// ------ ------
+
+fn init(_: Url, _orders: &mut impl Orders<Msg>) -> Model {
+    Model { inputs: vec![1] }
+}
+
+// ------ ------
+//     Model
+// ------ ------
+
+struct Model {
+    inputs: Vec<u32>,
+}
+
+// ------ ------
+//    Update
+// ------ ------
+
+enum Msg {
+    AddBox,
+    RemoveBox(u32),
+}
+
+fn update(msg: Msg, model: &mut Model, _orders: &mut impl Orders<Msg>) {
+    match msg {
+        Msg::AddBox => model
+            .inputs
+            .push(model.inputs.iter().max().unwrap_or(&0) + 1),
+        Msg::RemoveBox(id_to_remove) => model.inputs.retain(|id| id != &id_to_remove),
+    }
+}
+
+// ------ ------
+//     View
+// ------ ------
+
+fn view(model: &Model) -> Node<Msg> {
+    div![
+        style! {
+            St::Width => vw(100),
+            St::Height => vh(100),
+            St::Display => "flex",
+            St::FlexDirection => "column",
+            St::JustifyContent => "center",
+            St::AlignItems => "center",
+        },
+        button![ev(Ev::Click, |_| Msg::AddBox), "Add Input"],
+        model.inputs.iter().map(|id| {
+            let id = *id;
+            div![
+                input![on_insert(|el| el
+                    .dyn_into::<web_sys::HtmlElement>()
+                    .unwrap()
+                    .focus()
+                    .unwrap())],
+                button![ev(Ev::Click, move |_| Msg::RemoveBox(id)), "Remove"]
+            ]
+        })
+    ]
+}
+
+// ------ ------
+//     Start
+// ------ ------
+
+#[wasm_bindgen(start)]
+pub fn start() {
+    App::start("app", init, update, view);
+}

--- a/src/browser/dom/virtual_dom_bridge.rs
+++ b/src/browser/dom/virtual_dom_bridge.rs
@@ -546,7 +546,7 @@ fn wire_up_el<Ms>(el: &mut El<Ms>, mailbox: &Mailbox<Ms>) {
         .attach_listeners(el_ws.clone(), None, mailbox);
 
     for handler in &el.insert_handlers {
-        let msg = handler.0(el_ws.clone());
-        mailbox.send(Some(msg));
+        let maybe_msg = handler.0(el_ws.clone());
+        mailbox.send(maybe_msg);
     }
 }

--- a/src/browser/dom/virtual_dom_bridge.rs
+++ b/src/browser/dom/virtual_dom_bridge.rs
@@ -179,6 +179,12 @@ pub fn attach_el_and_children<Ms>(el: &mut El<Ms>, parent: &web_sys::Node, mailb
     el.event_handler_manager
         .attach_listeners(el_ws.clone(), None, mailbox);
 
+    for handler in &el.insert_handlers {
+        log!("attach_el_and_children");
+        let msg = handler.0(el_ws.clone());
+        mailbox.send(Some(msg));
+    }
+
     // appending the its children to the el_ws
     for child in &mut el.children {
         match child {

--- a/src/browser/dom/virtual_dom_bridge.rs
+++ b/src/browser/dom/virtual_dom_bridge.rs
@@ -532,20 +532,23 @@ pub(crate) fn replace_child(new: &web_sys::Node, old: &web_sys::Node, parent: &w
 
 #[inline]
 fn wire_up_el<Ms>(el: &mut El<Ms>, mailbox: &Mailbox<Ms>) {
-    // TODO: Cannot pass `el_ws` into this function, because it would borrow `el` both mutably and immutably
-    let el_ws = el
+    let node_ws = el
         .node_ws
         .as_ref()
         .expect("Missing websys el in attach_el_and_children");
 
     for ref_ in &mut el.refs {
-        ref_.set(el_ws.clone());
+        ref_.set(node_ws.clone());
     }
 
     el.event_handler_manager
-        .attach_listeners(el_ws.clone(), None, mailbox);
+        .attach_listeners(node_ws.clone(), None, mailbox);
 
     for handler in &el.insert_handlers {
+        let el_ws = node_ws
+            .dyn_ref::<web_sys::Element>()
+            .expect("Problem casting Node as Element while wiring up el");
+
         let maybe_msg = handler.0(el_ws.clone());
         mailbox.send(maybe_msg);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,9 +198,9 @@ pub mod prelude {
         // https://github.com/rust-lang-nursery/reference/blob/master/src/macros-by-example.md
         shortcuts::*,
         virtual_dom::{
-            el_key, el_ref::el_ref, AsAtValue, At, AtValue, CSSValue, El, ElRef, Ev, EventHandler,
-            IntoNodes, Node, St, Tag, ToClasses, UpdateEl, UpdateElForIterator,
-            UpdateElForOptionIterator, View,
+            el_key, el_ref::el_ref, on_insert, AsAtValue, At, AtValue, CSSValue, El, ElRef, Ev,
+            EventHandler, InsertEventHandler, IntoNodes, Node, St, Tag, ToClasses, UpdateEl,
+            UpdateElForIterator, UpdateElForOptionIterator, View,
         },
     };
     pub use indexmap::IndexMap; // for attrs and style to work.

--- a/src/virtual_dom.rs
+++ b/src/virtual_dom.rs
@@ -14,7 +14,7 @@ pub use attrs::Attrs;
 pub use el_ref::{el_ref, ElRef, SharedNodeWs};
 pub use event_handler_manager::{EventHandler, EventHandlerManager, Listener};
 pub use mailbox::Mailbox;
-pub use node::{el_key, El, ElKey, IntoNodes, Node, Text};
+pub use node::{el_key, on_insert, El, ElKey, InsertEventHandler, IntoNodes, Node, Text};
 pub use style::Style;
 pub use to_classes::ToClasses;
 pub use update_el::{UpdateEl, UpdateElForIterator, UpdateElForOptionIterator};

--- a/src/virtual_dom/node.rs
+++ b/src/virtual_dom/node.rs
@@ -8,7 +8,7 @@ pub mod el;
 pub mod into_nodes;
 pub mod text;
 
-pub use el::{el_key, El, ElKey};
+pub use el::{el_key, on_insert, El, ElKey, InsertEventHandler};
 pub use into_nodes::IntoNodes;
 pub use text::Text;
 

--- a/src/virtual_dom/node/el.rs
+++ b/src/virtual_dom/node/el.rs
@@ -314,7 +314,7 @@ impl<Ms> El<Ms> {
     }
 }
 
-pub struct InsertEventHandler<Ms>(pub(crate) Rc<dyn Fn(web_sys::Node) -> Option<Ms>>);
+pub struct InsertEventHandler<Ms>(pub(crate) Rc<dyn Fn(web_sys::Element) -> Option<Ms>>);
 
 impl<Ms> fmt::Debug for InsertEventHandler<Ms> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -325,10 +325,10 @@ impl<Ms> fmt::Debug for InsertEventHandler<Ms> {
 /// Attaches an event handler that will trigger the given `Msg` when the element
 /// is inserted into the DOM.
 pub fn on_insert<Ms: 'static, MsU: 'static>(
-    handler: impl FnOnce(web_sys::Node) -> MsU + 'static + Clone,
+    handler: impl FnOnce(web_sys::Element) -> MsU + 'static + Clone,
 ) -> InsertEventHandler<Ms> {
     let handler = map_callback_return_to_option_ms!(
-        dyn Fn(web_sys::Node) -> Option<Ms>,
+        dyn Fn(web_sys::Element) -> Option<Ms>,
         handler.clone(),
         "Handler can return only Msg, Option<Msg> or ()!",
         Rc

--- a/src/virtual_dom/node/el.rs
+++ b/src/virtual_dom/node/el.rs
@@ -324,6 +324,12 @@ impl<Ms> fmt::Debug for InsertEventHandler<Ms> {
 
 /// Attaches an event handler that will trigger the given `Msg` when the element
 /// is inserted into the DOM.
+///
+/// Handler has to return `Msg`, `Option<Msg>` or `()`.
+///
+/// # Panics
+///
+/// Panics when the handler doesn't return `Msg` or `()`. (It will be changed to a compile-time error).
 pub fn on_insert<Ms: 'static, MsU: 'static>(
     handler: impl FnOnce(web_sys::Element) -> MsU + 'static + Clone,
 ) -> InsertEventHandler<Ms> {

--- a/src/virtual_dom/patch.rs
+++ b/src/virtual_dom/patch.rs
@@ -36,21 +36,7 @@ fn insert_el<'a, Ms>(
     mailbox: &Mailbox<Ms>,
 ) {
     virtual_dom_bridge::assign_ws_nodes_to_el(document, new);
-    virtual_dom_bridge::attach_children(new, mailbox);
-    let new_node = new
-        .node_ws
-        .take()
-        .expect("Missing websys el when patching Text to Element");
-    virtual_dom_bridge::insert_node(&new_node, parent, Some(next_node));
-
-    for ref_ in &mut new.refs {
-        ref_.set(new_node.clone());
-    }
-
-    new.event_handler_manager
-        .attach_listeners(new_node.clone(), None, mailbox);
-
-    new.node_ws.replace(new_node);
+    virtual_dom_bridge::insert_el_and_children(new, parent, Some(next_node), mailbox);
 }
 
 fn insert_text<'a>(
@@ -90,10 +76,6 @@ fn patch_el<'a, Ms, Mdl, INodes>(
         .clone();
     virtual_dom_bridge::patch_el_details(&mut old, new, &old_el_ws, mailbox);
 
-    for ref_ in &mut new.refs {
-        ref_.set(old_el_ws.clone());
-    }
-
     let old_children_iter = old.children.into_iter();
     let new_children_iter = new.children.iter_mut();
 
@@ -128,9 +110,6 @@ fn replace_by_el<'a, Ms>(
     mailbox: &Mailbox<Ms>,
 ) {
     let new_node = virtual_dom_bridge::make_websys_el(new, document);
-    for ref_ in &mut new.refs {
-        ref_.set(new_node.clone());
-    }
     new.node_ws = Some(new_node);
     for mut child in &mut new.children {
         virtual_dom_bridge::assign_ws_nodes(document, &mut child);

--- a/src/virtual_dom/update_el.rs
+++ b/src/virtual_dom/update_el.rs
@@ -1,4 +1,4 @@
-use super::{Attrs, El, ElKey, ElRef, EventHandler, Node, Style, Tag, Text};
+use super::{Attrs, El, ElKey, ElRef, EventHandler, InsertEventHandler, Node, Style, Tag, Text};
 
 // ------ Traits ------
 
@@ -45,6 +45,12 @@ impl<Ms> UpdateEl<Ms> for Style {
 impl<Ms> UpdateEl<Ms> for EventHandler<Ms> {
     fn update_el(self, el: &mut El<Ms>) {
         el.event_handler_manager.add_event_handlers(vec![self]);
+    }
+}
+
+impl<Ms> UpdateEl<Ms> for InsertEventHandler<Ms> {
+    fn update_el(self, el: &mut El<Ms>) {
+        el.insert_handlers.push(self);
     }
 }
 


### PR DESCRIPTION
This is an attempt at adding an `on_insert` "attribute" to `El`. The purpose of this is to simplify the initialization of inserted dom elements, as the current approach of using `el_ref` and `orders.after_render` can get very hairy if the element is inserted (and re-inserted) based on some non-trivial condition. Using `on_insert` to handle the lifecycle for you ensures the element is always initialized. It also removes a bit of boilerplate even in the trivial scenarios, which is nice.

My understanding of the virtual dom is a bit shaky though, hence the draft. I'm pretty sure I'm overdoing the triggering, as I've just added triggering wherever `ElRef`s are being set.

I've also not gotten the example to work correctly, as there seems to be some caching of nodes that prevent it from being re-inserted when toggled. Or I've missed adding a trigger to an insertion point somewhere. I will look further into it later, but would appreciate any advice you might have.