### PR TITLE
Fix 619

### DIFF
--- a/src/browser/fetch.rs
+++ b/src/browser/fetch.rs
@@ -90,6 +90,7 @@ pub async fn fetch<'a>(request: impl Into<Request<'a>>) -> Result<Response> {
 #[derive(Debug)]
 pub enum FetchError {
     SerdeError(swb::Error),
+    StringifyError(wasm_bindgen::JsValue),
     DomException(web_sys::DomException),
     PromiseError(wasm_bindgen::JsValue),
     NetworkError(wasm_bindgen::JsValue),

--- a/src/browser/fetch/request.rs
+++ b/src/browser/fetch/request.rs
@@ -95,8 +95,9 @@ impl<'a> Request<'a> {
     /// This method can fail if JSON serialization fail. It will then
     /// return `FetchError::SerdeError`.
     pub fn json<T: Serialize + ?Sized>(mut self, data: &T) -> Result<Self> {
-        let body = swb::to_value(data)?;
-        self.body = Some(Cow::Owned(body));
+        let body = data.serialize(&swb::Serializer::json_compatible())?;
+        let body = js_sys::JSON::stringify(&body).map_err(FetchError::StringifyError)?;
+        self.body = Some(Cow::Owned(body.into()));
         Ok(self.header(Header::content_type("application/json; charset=utf-8")))
     }
 


### PR DESCRIPTION
This is a quick fix but I'd prefer to use a feature flags like `swb-json` that is disabled and use `serde-json` instead by default (see #660).