### PR TITLE
serde json and swb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Added `sl_input` to the `custom_elements` example.
 - [BREAKING] Changed `Request.body` to take its argument by reference.
 - Adapted to Rust 1.53.0.
-- Removed internal `serde_json` usage in favour of `serde-wasm-bindgen`. This reduces final binary size for downstream users.
+- Added `swb` and `serde-json` features to use either `serde-wasm-bindgen` or `serde_json`. `swb` reduces final binary size for downstream users.
 - [BREAKING] Removed the deprecated `browser::service::fetch` module.
 - Element macros like `div!` can now contain `Iterator`s inside of `Option` values. Previously only one or the other was possible.
 - Add method to return detailed error response from server with `FetchError`.
@@ -34,6 +34,7 @@
 - Added `charts` example.
 - Added `page_trait` example.
 - Added `on_insert` event on elements, triggered when they are inserted into the DOM.
+- [BREAKING] `fetch::Error::SerdeError` changed to `fetch::Error::JsonError`
 
 ## v0.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,6 +3018,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ pulldown-cmark = { version = "0.9.1", optional = true }
 rand = { version = "0.8.5", features = ["small_rng"] }
 # https://docs.rs/getrandom/0.2.0/getrandom/#webassembly-support
 getrandom = { version = "0.2.5", features = ["js"] }
-serde = { version = "1.0.136", features = ['derive'] }
+serde = { version = "1.0.136", features = ['derive'], optional = true }
 serde_json = { version = "1.0", optional = true }
 serde-wasm-bindgen = { version = "0.4.2", optional = true }
 wasm-bindgen = "0.2.78" # v0.2.79 is not working, see https://github.com/rustwasm/wasm-bindgen/issues/2774
@@ -172,7 +172,7 @@ exclude = [
 
 [features]
 default = ["panic-hook", "serde-json"]
-serde-json = ["serde_json", "wasm-bindgen/serde-serialize"]
-swb = ["serde-wasm-bindgen"]
+serde-json = ["serde", "serde_json", "wasm-bindgen/serde-serialize"]
+swb = ["serde", "serde-wasm-bindgen"]
 panic-hook = ["console_error_panic_hook"]
 markdown = ["pulldown-cmark"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ version_check = "0.9.4"
 [dev-dependencies]
 wasm-bindgen-test = "0.3.28"
 serde_json = "1.0.79"
+serde-wasm-bindgen = "0.4.2"
 
 [dependencies]
 console_error_panic_hook = { version = "0.1.7", optional = true }
@@ -35,7 +36,8 @@ rand = { version = "0.8.5", features = ["small_rng"] }
 # https://docs.rs/getrandom/0.2.0/getrandom/#webassembly-support
 getrandom = { version = "0.2.5", features = ["js"] }
 serde = { version = "1.0.136", features = ['derive'] }
-serde-wasm-bindgen = "0.4.2"
+serde_json = { version = "1.0", optional = true }
+serde-wasm-bindgen = { version = "0.4.2", optional = true }
 wasm-bindgen = "0.2.78" # v0.2.79 is not working, see https://github.com/rustwasm/wasm-bindgen/issues/2774
 wasm-bindgen-futures = "0.4.28"
 # @TODO: remove once we can use entities without `Debug` in `log!` and `error!` on `stable` Rust.
@@ -169,6 +171,7 @@ exclude = [
 ]
 
 [features]
-default = ["panic-hook"]
+default = ["panic-hook", "serde_json", "wasm-bindgen/serde-serialize"]
+swb = ["serde-wasm-bindgen"]
 panic-hook = ["console_error_panic_hook"]
 markdown = ["pulldown-cmark"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,8 @@ exclude = [
 ]
 
 [features]
-default = ["panic-hook", "serde_json", "wasm-bindgen/serde-serialize"]
+default = ["panic-hook", "serde-json"]
+serde-json = ["serde_json", "wasm-bindgen/serde-serialize"]
 swb = ["serde-wasm-bindgen"]
 panic-hook = ["console_error_panic_hook"]
 markdown = ["pulldown-cmark"]

--- a/src/app/orders.rs
+++ b/src/app/orders.rs
@@ -1,4 +1,7 @@
-use super::{subs, App, CmdHandle, RenderInfo, StreamHandle, SubHandle};
+#[cfg(any(feature = "serde-json", feature = "swb"))]
+use super::subs;
+use super::{App, CmdHandle, RenderInfo, StreamHandle, SubHandle};
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 use crate::browser::Url;
 use crate::virtual_dom::IntoNodes;
 use futures::stream::Stream;
@@ -318,6 +321,7 @@ pub trait Orders<Ms: 'static> {
     /// Simulate `<a href="[url]">` element click.
     ///
     /// A thin wrapper for `orders.notify(subs::UrlRequested::new(url))`
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     fn request_url(&mut self, url: Url) -> &mut Self {
         self.notify(subs::UrlRequested::new(url))
     }

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,5 +1,6 @@
 pub mod dom;
 pub mod fetch;
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 mod json;
 pub mod service;
 pub mod url;

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,5 +1,6 @@
 pub mod dom;
 pub mod fetch;
+mod json;
 pub mod service;
 pub mod url;
 pub mod util;

--- a/src/browser/fetch.rs
+++ b/src/browser/fetch.rs
@@ -28,7 +28,9 @@
 //! [status]: ./struct.Status.html
 //! [fetch-mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
 
-use crate::{browser::json, util::window};
+#[cfg(any(feature = "serde-json", feature = "swb"))]
+use crate::browser::json;
+use crate::util::window;
 use std::convert::TryInto;
 use wasm_bindgen_futures::JsFuture;
 
@@ -88,6 +90,7 @@ pub async fn fetch<'a>(request: impl Into<Request<'a>>) -> Result<Response> {
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 pub enum FetchError {
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     JsonError(json::Error),
     DomException(web_sys::DomException),
     PromiseError(wasm_bindgen::JsValue),
@@ -97,6 +100,7 @@ pub enum FetchError {
     StatusError(Status),
 }
 
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 impl From<json::Error> for FetchError {
     fn from(v: json::Error) -> Self {
         Self::JsonError(v)

--- a/src/browser/fetch.rs
+++ b/src/browser/fetch.rs
@@ -28,8 +28,7 @@
 //! [status]: ./struct.Status.html
 //! [fetch-mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
 
-use crate::util::window;
-use serde_wasm_bindgen as swb;
+use crate::{browser::json, util::window};
 use std::convert::TryInto;
 use wasm_bindgen_futures::JsFuture;
 
@@ -89,8 +88,7 @@ pub async fn fetch<'a>(request: impl Into<Request<'a>>) -> Result<Response> {
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 pub enum FetchError {
-    SerdeError(swb::Error),
-    StringifyError(wasm_bindgen::JsValue),
+    JsonError(json::Error),
     DomException(web_sys::DomException),
     PromiseError(wasm_bindgen::JsValue),
     NetworkError(wasm_bindgen::JsValue),
@@ -100,9 +98,9 @@ pub enum FetchError {
     ConversionError,
 }
 
-impl From<swb::Error> for FetchError {
-    fn from(v: swb::Error) -> Self {
-        Self::SerdeError(v)
+impl From<json::Error> for FetchError {
+    fn from(v: json::Error) -> Self {
+        Self::JsonError(v)
     }
 }
 

--- a/src/browser/fetch.rs
+++ b/src/browser/fetch.rs
@@ -95,7 +95,6 @@ pub enum FetchError {
     /// Request construction failed.
     RequestError(wasm_bindgen::JsValue),
     StatusError(Status),
-    ConversionError,
 }
 
 impl From<json::Error> for FetchError {

--- a/src/browser/fetch/form_data.rs
+++ b/src/browser/fetch/form_data.rs
@@ -19,7 +19,9 @@
 //! See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/FormData) for
 //! details on the behavior of the underlying API.
 
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 use crate::{browser::json, fetch::Result};
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 use serde::Serialize;
 use wasm_bindgen::JsValue;
 
@@ -60,6 +62,7 @@ impl FormData {
     /// ## Errors
     /// Will return `Err` if serialization fails.
     #[allow(clippy::missing_panics_doc)]
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     pub fn append_json<T>(&mut self, name: &str, data: &T) -> Result<()>
     where
         T: Serialize + ?Sized,
@@ -73,6 +76,7 @@ impl FormData {
     ///
     /// ## Errors
     /// Will return `Err` if serialization fails.
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     pub fn with_json<T>(mut self, name: &str, data: &T) -> Result<Self>
     where
         T: Serialize + ?Sized,

--- a/src/browser/fetch/form_data.rs
+++ b/src/browser/fetch/form_data.rs
@@ -19,10 +19,8 @@
 //! See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/FormData) for
 //! details on the behavior of the underlying API.
 
-use crate::fetch::{FetchError, Result};
-use js_sys::JSON;
+use crate::{browser::json, fetch::Result};
 use serde::Serialize;
-use serde_wasm_bindgen as swb;
 use wasm_bindgen::JsValue;
 
 pub struct FormData(web_sys::FormData);
@@ -67,9 +65,7 @@ impl FormData {
         T: Serialize + ?Sized,
     {
         // @TODO Can a different `append` be used to append a `JsValue` directly?
-        let str: String = JSON::stringify(&swb::to_value(data)?)
-            .map_err(|_| FetchError::ConversionError)?
-            .into();
+        let str: String = json::to_string(data)?;
         self.0.append_with_str(name, &str).unwrap();
         Ok(())
     }

--- a/src/browser/fetch/request.rs
+++ b/src/browser/fetch/request.rs
@@ -2,11 +2,10 @@
 
 use super::form_data::FormData;
 use super::{fetch, FetchError, Header, Headers, Method, Response, Result};
-use crate::browser::Url;
+use crate::browser::{json, Url};
 use gloo_timers::callback::Timeout;
 use js_sys::Uint8Array;
 use serde::Serialize;
-use serde_wasm_bindgen as swb;
 use std::{borrow::Cow, cell::RefCell, rc::Rc};
 use wasm_bindgen::JsValue;
 
@@ -95,8 +94,7 @@ impl<'a> Request<'a> {
     /// This method can fail if JSON serialization fail. It will then
     /// return `FetchError::SerdeError`.
     pub fn json<T: Serialize + ?Sized>(mut self, data: &T) -> Result<Self> {
-        let body = data.serialize(&swb::Serializer::json_compatible())?;
-        let body = js_sys::JSON::stringify(&body).map_err(FetchError::StringifyError)?;
+        let body = json::to_js_string(data)?;
         self.body = Some(Cow::Owned(body.into()));
         Ok(self.header(Header::content_type("application/json; charset=utf-8")))
     }

--- a/src/browser/fetch/request.rs
+++ b/src/browser/fetch/request.rs
@@ -2,9 +2,12 @@
 
 use super::form_data::FormData;
 use super::{fetch, FetchError, Header, Headers, Method, Response, Result};
-use crate::browser::{json, Url};
+#[cfg(any(feature = "serde-json", feature = "swb"))]
+use crate::browser::json;
+use crate::browser::Url;
 use gloo_timers::callback::Timeout;
 use js_sys::Uint8Array;
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 use serde::Serialize;
 use std::{borrow::Cow, cell::RefCell, rc::Rc};
 use wasm_bindgen::JsValue;
@@ -93,6 +96,7 @@ impl<'a> Request<'a> {
     ///
     /// This method can fail if JSON serialization fail. It will then
     /// return `FetchError::SerdeError`.
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     pub fn json<T: Serialize + ?Sized>(mut self, data: &T) -> Result<Self> {
         let body = json::to_js_string(data)?;
         self.body = Some(Cow::Owned(body.into()));

--- a/src/browser/fetch/response.rs
+++ b/src/browser/fetch/response.rs
@@ -1,8 +1,11 @@
 //! The Response interface of the Fetch API represents the response to a request.
 
 use super::{FetchError, Headers, Result, Status};
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 use crate::browser::json;
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 use serde::de::DeserializeOwned;
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
 
@@ -36,6 +39,7 @@ impl Response {
     ///
     /// # Errors
     /// Returns `FetchError::SerdeError` or `FetchError::PromiseError`.
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     pub async fn json<T: DeserializeOwned + 'static>(&self) -> Result<T> {
         let js: JsValue = self
             .raw_response

--- a/src/browser/fetch/response.rs
+++ b/src/browser/fetch/response.rs
@@ -1,8 +1,8 @@
 //! The Response interface of the Fetch API represents the response to a request.
 
 use super::{FetchError, Headers, Result, Status};
+use crate::browser::json;
 use serde::de::DeserializeOwned;
-use serde_wasm_bindgen as swb;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
 
@@ -45,7 +45,7 @@ impl Response {
             .await
             .map_err(FetchError::PromiseError)?;
 
-        Ok(swb::from_value(js)?)
+        Ok(json::from_js_value(&js)?)
     }
 
     /// Return response body as `Vec<u8>`.

--- a/src/browser/json.rs
+++ b/src/browser/json.rs
@@ -1,0 +1,14 @@
+use serde::{de::DeserializeOwned, Serialize};
+use wasm_bindgen::JsValue;
+
+#[derive(Debug)]
+pub enum Error {
+    Serde(JsValue),
+    Parse(JsValue),
+    Stringify(JsValue),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+mod swb;
+pub use swb::*;

--- a/src/browser/json.rs
+++ b/src/browser/json.rs
@@ -15,7 +15,7 @@ mod swb;
 #[cfg(feature = "swb")]
 pub use swb::*;
 
-#[cfg(feature = "serde-json")]
+#[cfg(all(not(feature = "swb"), feature = "serde-json"))]
 mod serde_json;
-#[cfg(feature = "serde-json")]
+#[cfg(all(not(feature = "swb"), feature = "serde-json"))]
 pub use self::serde_json::*;

--- a/src/browser/json.rs
+++ b/src/browser/json.rs
@@ -10,5 +10,12 @@ pub enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
+#[cfg(feature = "swb")]
 mod swb;
+#[cfg(feature = "swb")]
 pub use swb::*;
+
+#[cfg(not(feature = "swb"))]
+mod serde_json;
+#[cfg(not(feature = "swb"))]
+pub use self::serde_json::*;

--- a/src/browser/json.rs
+++ b/src/browser/json.rs
@@ -15,7 +15,7 @@ mod swb;
 #[cfg(feature = "swb")]
 pub use swb::*;
 
-#[cfg(not(feature = "swb"))]
+#[cfg(feature = "serde-json")]
 mod serde_json;
-#[cfg(not(feature = "swb"))]
+#[cfg(feature = "serde-json")]
 pub use self::serde_json::*;

--- a/src/browser/json/serde_json.rs
+++ b/src/browser/json/serde_json.rs
@@ -1,0 +1,46 @@
+use super::*;
+use js_sys::JsString;
+
+impl From<::serde_json::Error> for Error {
+    fn from(err: ::serde_json::Error) -> Self {
+        Error::Serde(JsValue::from(err.to_string()))
+    }
+}
+
+pub fn to_string<T>(v: &T) -> Result<String>
+where
+    T: Serialize + ?Sized,
+{
+    Ok(::serde_json::to_string(v)?)
+}
+
+pub fn to_js_string<T>(v: &T) -> Result<JsString>
+where
+    T: Serialize + ?Sized,
+{
+    let v = to_string(v)?;
+    let js_string = JsString::from(v);
+    Ok(js_string)
+}
+
+pub fn from_str<T>(v: &str) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let v = ::serde_json::from_str(v)?;
+    Ok(v)
+}
+
+pub fn from_js_value<T>(v: &JsValue) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    Ok(v.into_serde()?)
+}
+
+pub fn to_js_value<T>(v: &T) -> Result<JsValue>
+where
+    T: Serialize + ?Sized,
+{
+    Ok(JsValue::from_serde(v)?)
+}

--- a/src/browser/json/swb.rs
+++ b/src/browser/json/swb.rs
@@ -24,11 +24,11 @@ where
     Ok(js_string)
 }
 
-pub fn from_str<T>(data: &str) -> Result<T>
+pub fn from_str<T>(v: &str) -> Result<T>
 where
     T: DeserializeOwned,
 {
-    let v = JSON::parse(data).map_err(Error::Parse)?;
+    let v = JSON::parse(v).map_err(Error::Parse)?;
     let v = from_js_value(&v)?;
     Ok(v)
 }

--- a/src/browser/json/swb.rs
+++ b/src/browser/json/swb.rs
@@ -1,0 +1,49 @@
+use super::*;
+use js_sys::{JsString, JSON};
+use serde_wasm_bindgen as swb;
+
+impl From<swb::Error> for Error {
+    fn from(err: swb::Error) -> Self {
+        Error::Serde(err.into())
+    }
+}
+
+pub fn to_string<T>(v: &T) -> Result<String>
+where
+    T: Serialize + ?Sized,
+{
+    Ok(to_js_string(v)?.into())
+}
+
+pub fn to_js_string<T>(v: &T) -> Result<JsString>
+where
+    T: Serialize + ?Sized,
+{
+    let v = to_js_value(v)?;
+    let js_string = JSON::stringify(&v).map_err(Error::Stringify)?;
+    Ok(js_string)
+}
+
+pub fn from_str<T>(data: &str) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let v = JSON::parse(data).map_err(Error::Parse)?;
+    let v = from_js_value(&v)?;
+    Ok(v)
+}
+
+pub fn from_js_value<T>(v: &JsValue) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let v = swb::from_value(v.into())?;
+    Ok(v)
+}
+
+pub fn to_js_value<T>(v: &T) -> Result<JsValue>
+where
+    T: Serialize + ?Sized,
+{
+    Ok(v.serialize(&swb::Serializer::json_compatible())?)
+}

--- a/src/browser/service.rs
+++ b/src/browser/service.rs
@@ -1,1 +1,2 @@
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 pub(crate) mod routing;

--- a/src/browser/service/routing.rs
+++ b/src/browser/service/routing.rs
@@ -2,8 +2,10 @@ use super::super::{
     util::{self, ClosureNew},
     Url,
 };
-use crate::app::{subs, Notification};
-use serde_wasm_bindgen as swb;
+use crate::{
+    app::{subs, Notification},
+    browser::json,
+};
 use std::rc::Rc;
 use wasm_bindgen::{closure::Closure, JsCast};
 
@@ -14,7 +16,7 @@ use wasm_bindgen::{closure::Closure, JsCast};
 pub fn push_route<U: Into<Url>>(url: U) -> Url {
     let url = url.into();
     // We use data to evaluate the path instead of the path displayed in the url.
-    let data = swb::to_value(&url).expect("Problem serializing route data");
+    let data = json::to_js_value(&url).expect("Problem serializing route data");
 
     util::history()
         .push_state_with_url(&data, "", Some(&url.to_string()))
@@ -32,7 +34,7 @@ pub fn setup_popstate_listener(
             .dyn_ref::<web_sys::PopStateEvent>()
             .expect("Problem casting as Popstate event");
 
-        let url = match swb::from_value(ev.state()) {
+        let url = match json::from_js_value(&ev.state()) {
             Ok(url) => url,
             // Only update when requested for an update by the user.
             Err(_) => Url::current(),

--- a/src/browser/url.rs
+++ b/src/browser/url.rs
@@ -1,6 +1,7 @@
 #[cfg(any(feature = "serde-json", feature = "swb"))]
 use crate::browser::json;
 use crate::browser::util;
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::BTreeMap, fmt, str::FromStr};
 use wasm_bindgen::JsValue;
@@ -17,7 +18,11 @@ pub const DUMMY_BASE_URL: &str = "http://example.com";
 /// are considered different also during comparison.
 ///
 /// (If the features above are problems for you, create an [issue](https://github.com/seed-rs/seed/issues/new))
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(
+    any(feature = "serde-json", feature = "swb"),
+    derive(Serialize, Deserialize)
+)]
 pub struct Url {
     next_path_part_index: usize,
     next_hash_path_part_index: usize,
@@ -610,7 +615,11 @@ impl From<&web_sys::Url> for Url {
 // ------ UrlSearch ------
 
 #[allow(clippy::module_name_repetitions)]
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq)]
+#[cfg_attr(
+    any(feature = "serde-json", feature = "swb"),
+    derive(Serialize, Deserialize)
+)]
 pub struct UrlSearch {
     search: BTreeMap<String, Vec<String>>,
     invalid_components: Vec<String>,

--- a/src/browser/url.rs
+++ b/src/browser/url.rs
@@ -1,4 +1,6 @@
-use crate::browser::{json, util};
+#[cfg(any(feature = "serde-json", feature = "swb"))]
+use crate::browser::json;
+use crate::browser::util;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::BTreeMap, fmt, str::FromStr};
 use wasm_bindgen::JsValue;
@@ -38,6 +40,7 @@ impl Url {
     ///
     /// # References
     /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/History_API)
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     pub fn go_and_push(&self) {
         // We use data to evaluate the path instead of the path displayed in the url.
         let data: JsValue = json::to_js_value(self).expect("Problem serializing route data");
@@ -53,6 +56,8 @@ impl Url {
     ///
     /// # References
     /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/History_API)
+
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     pub fn go_and_replace(&self) {
         // We use data to evaluate the path instead of the path displayed in the url.
         let data: JsValue = json::to_js_value(self).expect("Problem serializing route data");

--- a/src/browser/url.rs
+++ b/src/browser/url.rs
@@ -1,6 +1,5 @@
-use crate::browser::util;
+use crate::browser::{json, util};
 use serde::{Deserialize, Serialize};
-use serde_wasm_bindgen as swb;
 use std::{borrow::Cow, collections::BTreeMap, fmt, str::FromStr};
 use wasm_bindgen::JsValue;
 
@@ -41,7 +40,7 @@ impl Url {
     /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/History_API)
     pub fn go_and_push(&self) {
         // We use data to evaluate the path instead of the path displayed in the url.
-        let data: JsValue = swb::to_value(self).expect("Problem serializing route data");
+        let data: JsValue = json::to_js_value(self).expect("Problem serializing route data");
 
         util::history()
             .push_state_with_url(&data, "", Some(&self.to_string()))
@@ -56,7 +55,7 @@ impl Url {
     /// * [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/History_API)
     pub fn go_and_replace(&self) {
         // We use data to evaluate the path instead of the path displayed in the url.
-        let data: JsValue = swb::to_value(self).expect("Problem serializing route data");
+        let data: JsValue = json::to_js_value(self).expect("Problem serializing route data");
 
         util::history()
             .replace_state_with_url(&data, "", Some(&self.to_string()))

--- a/src/browser/web_socket.rs
+++ b/src/browser/web_socket.rs
@@ -52,7 +52,6 @@ pub enum WebSocketError {
     TextError(&'static str),
     SendError(JsValue),
     JsonError(json::Error),
-    ConversionError,
     PromiseError(JsValue),
     FileReaderError(FileReadError),
     OpenError(JsValue),

--- a/src/browser/web_socket.rs
+++ b/src/browser/web_socket.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::module_name_repetitions)]
 
-use crate::{app::Orders, browser::json};
+use crate::app::Orders;
+#[cfg(any(feature = "serde-json", feature = "swb"))]
+use crate::browser::json;
 use gloo_file::FileReadError;
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 use serde::Serialize;
 use wasm_bindgen::{JsCast, JsValue};
 
@@ -51,6 +54,7 @@ pub type CloseEvent = web_sys::CloseEvent;
 pub enum WebSocketError {
     TextError(&'static str),
     SendError(JsValue),
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     JsonError(json::Error),
     PromiseError(JsValue),
     FileReaderError(FileReadError),
@@ -58,6 +62,7 @@ pub enum WebSocketError {
     CloseError(JsValue),
 }
 
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 impl From<json::Error> for WebSocketError {
     fn from(v: json::Error) -> Self {
         Self::JsonError(v)
@@ -130,6 +135,7 @@ impl WebSocket {
     /// # Errors
     ///
     /// Returns error when JSON serialization or sending fails.
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     pub fn send_json<T: Serialize + ?Sized>(&self, data: &T) -> Result<()> {
         let data: String = json::to_string(data)?;
         self.send_text(data)

--- a/src/browser/web_socket/message.rs
+++ b/src/browser/web_socket/message.rs
@@ -1,6 +1,6 @@
 use super::{Result, WebSocketError};
+use crate::browser::json;
 use serde::de::DeserializeOwned;
-use serde_wasm_bindgen as swb;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::MessageEvent;
 
@@ -33,7 +33,7 @@ impl WebSocketMessage {
     where
         T: DeserializeOwned + 'static,
     {
-        swb::from_value(self.data.clone()).map_err(WebSocketError::SerdeError)
+        json::from_js_value(&self.data).map_err(WebSocketError::JsonError)
     }
 
     /// Return message data as `Vec<u8>`.

--- a/src/browser/web_socket/message.rs
+++ b/src/browser/web_socket/message.rs
@@ -1,5 +1,7 @@
 use super::{Result, WebSocketError};
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 use crate::browser::json;
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 use serde::de::DeserializeOwned;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::MessageEvent;
@@ -29,6 +31,7 @@ impl WebSocketMessage {
     ///
     /// Returns
     /// - `WebSocketError::SerdeError` when JSON decoding fails.
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     pub fn json<T>(&self) -> Result<T>
     where
         T: DeserializeOwned + 'static,

--- a/src/browser/web_storage.rs
+++ b/src/browser/web_storage.rs
@@ -1,4 +1,7 @@
-use crate::browser::{json, util::window};
+#[cfg(any(feature = "serde-json", feature = "swb"))]
+use crate::browser::json;
+use crate::browser::util::window;
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 use serde::{de::DeserializeOwned, Serialize};
 use wasm_bindgen::JsValue;
 use web_sys::Storage;
@@ -20,9 +23,11 @@ pub enum WebStorageError {
     RemoveError(JsValue),
     GetError(JsValue),
     InsertError(JsValue),
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     JsonError(json::Error),
 }
 
+#[cfg(any(feature = "serde-json", feature = "swb"))]
 impl From<json::Error> for WebStorageError {
     fn from(v: json::Error) -> Self {
         Self::JsonError(v)
@@ -161,6 +166,7 @@ pub trait WebStorage {
     /// or find the key or deserialize the value.
     ///
     /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem)
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     fn get<K, V>(key: K) -> Result<V>
     where
         K: AsRef<str>,
@@ -183,6 +189,7 @@ pub trait WebStorage {
     /// or serialize the value or insert/update the pair.
     ///
     /// [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/Storage/setItem)
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
     fn insert<K, V>(key: K, value: &V) -> Result<()>
     where
         K: AsRef<str>,

--- a/src/browser/web_storage.rs
+++ b/src/browser/web_storage.rs
@@ -21,7 +21,6 @@ pub enum WebStorageError {
     GetError(JsValue),
     InsertError(JsValue),
     JsonError(json::Error),
-    ConversionError,
 }
 
 impl From<json::Error> for WebStorageError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,9 +174,11 @@ pub fn set_timeout(handler: Box<dyn Fn()>, timeout: i32) {
 /// for element-creation macros, input event constructors, and the `History` struct.
 /// Expose the `wasm_bindgen` prelude.
 pub mod prelude {
+    #[cfg(any(feature = "serde-json", feature = "swb"))]
+    pub use crate::app::subs;
     pub use crate::{
         app::{
-            cmds, streams, subs, App, CmdHandle, GetElement, MessageMapper, Orders, RenderInfo,
+            cmds, streams, App, CmdHandle, GetElement, MessageMapper, Orders, RenderInfo,
             StreamHandle, SubHandle,
         },
         browser::dom::css_units::*,


### PR DESCRIPTION
This PR introduces two features: `serde-json` and `swb` and it makes `serde-json` as default again. If you like you use `serde-wasm-bindgen` instead, just enable the feature `swb`.