### PR TITLE
Failing testcase for serde::to_string -> WebSocketMessage -> serde::from_str bug

### DIFF
--- a/examples/e2e_encryption/Cargo.lock
+++ b/examples/e2e_encryption/Cargo.lock
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "seed"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "console_error_panic_hook",
  "cookie",

--- a/examples/server_integration/Cargo.lock
+++ b/examples/server_integration/Cargo.lock
@@ -1529,7 +1529,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "seed"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "console_error_panic_hook",
  "cookie 0.16.0",


### PR DESCRIPTION
Relevant issue: https://github.com/seed-rs/seed/issues/678

This PR adds a test case that fails (on my machine).

The error message I get is the same as the one reported in the issue.


🚨 🚨 🚨  The test case is not really intended to be merged now. It is just a test case to help figure out the issue.


```
GET http://127.0.0.1:8000/favicon.ico 404 (Not Found)
(index):15 panicked at 'called `Result::unwrap()` on an `Err` value: JsonError(Serde(JsValue("invalid type: string "{\"a\":1,\"b\":2}", expected struct Test at line 1 column 19")))', src/browser/web_socket/message.rs:165:45

Stack:

Error
    at http://127.0.0.1:8000/wasm-bindgen-test:1417:21
    at logError (http://127.0.0.1:8000/wasm-bindgen-test:218:18)
    at imports.wbg.__wbg_new_693216e109162396 (http://127.0.0.1:8000/wasm-bindgen-test:1416:66)
    at console_error_panic_hook::Error::new::hb8a49f01cbbd0d08 (http://127.0.0.1:8000/wasm-bindgen-test_bg.wasm:wasm-function[15372]:0x3e6868)
    at console_error_panic_hook::hook_impl::h7a36f16a30dbe787 (http://127.0.0.1:8000/wasm-bindgen-test_bg.wasm:wasm-function[1909]:0x208975)
    at console_error_panic_hook::hook::h6f98309c853f619e (http://127.0.0.1:8000/wasm-bindgen-test_bg.wasm:wasm-function[17173]:0x3fed67)
    at core::ops::function::Fn::call::hbdfee75e4f385855 (http://127.0.0.1:8000/wasm-bindgen-test_bg.wasm:wasm-function[14521]:0x3d945a)
    at std::panicking::rust_panic_with_hook::he2a025723e105e28 (http://127.0.0.1:8000/wasm-bindgen-test_bg.wasm:wasm-function[4009]:0x2a58e2)
    at std::panicking::begin_panic_handler::{{closure}}::hd9f8c213ec91b9d5 (http://127.0.0.1:8000/wasm-bindgen-test_bg.wasm:wasm-function[6748]:0x31ea52)
    at std::sys_common::backtrace::__rust_end_short_backtrace::h6efd730283875809 (http://127.0.0.1:8000/wasm-bindgen-test_bg.wasm:wasm-function[20094]:0x41a5e1)


console.<computed> @ (index):15
(anonymous) @ wasm-bindgen-test:1411
logError @ wasm-bindgen-test:218
imports.wbg.__wbg_error_09919627ac0992f5 @ wasm-bindgen-test:1409
$console_error_panic_hook::error::h6e077b80c1d280ae @ wasm-bindgen-test_bg.wasm:0x2efb5f
$console_error_panic_hook::hook_impl::h7a36f16a30dbe787 @ wasm-bindgen-test_bg.wasm:0x208a6d
$console_error_panic_hook::hook::h6f98309c853f619e @ wasm-bindgen-test_bg.wasm:0x3fed67
$core::ops::function::Fn::call::hbdfee75e4f385855 @ wasm-bindgen-test_bg.wasm:0x3d945a
$std::panicking::rust_panic_with_hook::he2a025723e105e28 @ wasm-bindgen-test_bg.wasm:0x2a58e2
$std::panicking::begin_panic_handler::{{closure}}::hd9f8c213ec91b9d5 @ wasm-bindgen-test_bg.wasm:0x31ea52
$std::sys_common::backtrace::__rust_end_short_backtrace::h6efd730283875809 @ wasm-bindgen-test_bg.wasm:0x41a5e1
$rust_begin_unwind @ wasm-bindgen-test_bg.wasm:0x3f09a2
$core::panicking::panic_fmt::hb02133958c1e7d35 @ wasm-bindgen-test_bg.wasm:0x3f3c8b
$core::result::unwrap_failed::h68fdaca771c68bb6 @ wasm-bindgen-test_bg.wasm:0x341df6
$core::result::Result<T,E>::unwrap::hc8bb85473dfc9efb @ wasm-bindgen-test_bg.wasm:0x296d98
$seed::browser::web_socket::message::tests::convert_message_to_struct::{{closure}}::h51375cedb7b1d330 @ wasm-bindgen-test_bg.wasm:0xbdda3
$<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hca4b9f432002aba7 @ wasm-bindgen-test_bg.wasm:0x2d9d70
$wasm_bindgen_test::__rt::Context::execute_async::{{closure}}::h737e03889c38d014 @ wasm-bindgen-test_bg.wasm:0x1fad92
$<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h235794b68f314a0d @ wasm-bindgen-test_bg.wasm:0x2d6e30
$<wasm_bindgen_test::__rt::TestFuture<F> as core::future::future::Future>::poll::{{closure}}::{{closure}}::h017d591f5b1e5a62 @ wasm-bindgen-test_bg.wasm:0x326d33
$wasm_bindgen::convert::closures::invoke0_mut::ha85700efd4d67511 @ wasm-bindgen-test_bg.wasm:0x2fc9c3
__wbg_adapter_57 @ wasm-bindgen-test:361
cb0 @ wasm-bindgen-test:560
window.__wbg_test_invoke @ (index):25
(anonymous) @ wasm-bindgen-test:565
handleError @ wasm-bindgen-test:366
imports.wbg.__wbg_wbgtestinvoke_ab9524aab0dff72e @ wasm-bindgen-test:553
$wasm_bindgen_test::__rt::__wbg_test_invoke::h5421c8d34e989b2a @ wasm-bindgen-test_bg.wasm:0x2575a9
$<wasm_bindgen_test::__rt::TestFuture<F> as core::future::future::Future>::poll::{{closure}}::h40b6aab7f31fcf3d @ wasm-bindgen-test_bg.wasm:0x2fe539
$scoped_tls::ScopedKey<T>::set::he1fe6d1ae8a9d97d @ wasm-bindgen-test_bg.wasm:0x28fed5
$<wasm_bindgen_test::__rt::TestFuture<F> as core::future::future::Future>::poll::h90a41184f542a083 @ wasm-bindgen-test_bg.wasm:0x13f153
$<wasm_bindgen_test::__rt::ExecuteTests as core::future::future::Future>::poll::h494addf2145278f0 @ wasm-bindgen-test_bg.wasm:0x99d8f
$wasm_bindgen_test::__rt::Context::run::{{closure}}::he8f0d1bee79949a9 @ wasm-bindgen-test_bg.wasm:0x1e4077
$<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hc4af2915b1480de1 @ wasm-bindgen-test_bg.wasm:0x2a1c4d
$wasm_bindgen_futures::future_to_promise::{{closure}}::{{closure}}::h05a1914718e9d1bc @ wasm-bindgen-test_bg.wasm:0x15f71c
$<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hb5d447c3bd9a70c5 @ wasm-bindgen-test_bg.wasm:0x2dbedb
$wasm_bindgen_futures::task::singlethread::Task::run::h69bd6b95bbd71845 @ wasm-bindgen-test_bg.wasm:0x1d6ce0
$wasm_bindgen_futures::queue::QueueState::run_all::h4f317e47a1e54fb8 @ wasm-bindgen-test_bg.wasm:0x1a1cc4
$wasm_bindgen_futures::queue::Queue::new::{{closure}}::h7cded913f56a2ab1 @ wasm-bindgen-test_bg.wasm:0x37f7d8
$<dyn core::ops::function::FnMut<(A,)>+Output = R as wasm_bindgen::closure::WasmClosure>::describe::invoke::h4e0948ea865d2c34 @ wasm-bindgen-test_bg.wasm:0x2bde09
__wbg_adapter_43 @ wasm-bindgen-test:267
real @ wasm-bindgen-test:201
Promise.then (async)
(anonymous) @ wasm-bindgen-test:1331
logError @ wasm-bindgen-test:218
imports.wbg.__wbg_then_ce526c837d07b68f @ wasm-bindgen-test:1330
$js_sys::Promise::then::hf86a2f5048416c70 @ wasm-bindgen-test_bg.wasm:0x3772e6
$wasm_bindgen_futures::queue::Queue::schedule_task::hc204f0615074c763 @ wasm-bindgen-test_bg.wasm:0x23369f
$wasm_bindgen_futures::task::singlethread::Task::spawn::{{closure}}::hc8f948c68984eaab @ wasm-bindgen-test_bg.wasm:0x3e6785
$std::thread::local::LocalKey<T>::try_with::h857a511143b989c2 @ wasm-bindgen-test_bg.wasm:0x27f6b2
$std::thread::local::LocalKey<T>::with::hb6689c30e02257b6 @ wasm-bindgen-test_bg.wasm:0x36e3b7
$wasm_bindgen_futures::task::singlethread::Task::spawn::h80ed2417ee25b0af @ wasm-bindgen-test_bg.wasm:0x187db3
$wasm_bindgen_futures::spawn_local::hd44028b0438146a8 @ wasm-bindgen-test_bg.wasm:0x208c27
$wasm_bindgen_futures::future_to_promise::{{closure}}::h6e39e785266f3455 @ wasm-bindgen-test_bg.wasm:0x25ee0b
$wasm_bindgen::convert::closures::invoke2_mut::h8d3d30111a2884a2 @ wasm-bindgen-test_bg.wasm:0x2a5610
__wbg_adapter_389 @ wasm-bindgen-test:387
cb0 @ wasm-bindgen-test:1315
(anonymous) @ wasm-bindgen-test:1320
logError @ wasm-bindgen-test:218
imports.wbg.__wbg_new_37705eed627d5ed9 @ wasm-bindgen-test:1308
$js_sys::Promise::new::h102b8fb65eaac159 @ wasm-bindgen-test_bg.wasm:0x35c069
$wasm_bindgen_futures::future_to_promise::hf5cde245a951a4e7 @ wasm-bindgen-test_bg.wasm:0x2a5333
$wasm_bindgen_test::__rt::Context::run::ha8cf726247475954 @ wasm-bindgen-test_bg.wasm:0xe56d5
$wasmbindgentestcontext_run @ wasm-bindgen-test_bg.wasm:0x264660
run @ wasm-bindgen-test:460
main @ run.js:33
await in main (async)
(anonymous) @ run.js:142
Show 12 more frames
```