### PR TITLE
Revert "Remove unused fields"

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use crate::browser::{
     util::{self, window},
     Url, DUMMY_BASE_URL,
 };
-use crate::virtual_dom::{patch, El, IntoNodes, Mailbox, Node, Tag};
+use crate::virtual_dom::{patch, El, EventHandlerManager, IntoNodes, Mailbox, Node, Tag};
 use enclose::{enc, enclose};
 use std::{
     any::Any,
@@ -175,6 +175,8 @@ where
                 model: RefCell::new(None),
                 root_el: RefCell::new(None),
                 popstate_closure: RefCell::new(None),
+                hashchange_closure: RefCell::new(None),
+                window_event_handler_manager: RefCell::new(EventHandlerManager::new()),
                 sub_manager: RefCell::new(SubManager::new()),
                 msg_listeners: RefCell::new(Vec::new()),
                 scheduled_render_handle: RefCell::new(None),

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -1,6 +1,6 @@
 use super::{RenderInfo, SubManager};
 use crate::browser::util;
-use crate::virtual_dom::El;
+use crate::virtual_dom::{El, EventHandlerManager};
 use std::cell::{Cell, RefCell};
 use wasm_bindgen::closure::Closure;
 
@@ -11,6 +11,8 @@ pub(crate) struct AppData<Ms: 'static, Mdl> {
     pub model: RefCell<Option<Mdl>>,
     pub(crate) root_el: RefCell<Option<El<Ms>>>,
     pub popstate_closure: StoredPopstate,
+    pub hashchange_closure: StoredPopstate,
+    pub window_event_handler_manager: RefCell<EventHandlerManager<Ms>>,
     pub sub_manager: RefCell<SubManager<Ms>>,
     pub msg_listeners: RefCell<Vec<Box<dyn Fn(&Ms)>>>,
     pub scheduled_render_handle: RefCell<Option<util::RequestAnimationFrameHandle>>,

--- a/src/browser/web_socket.rs
+++ b/src/browser/web_socket.rs
@@ -79,6 +79,7 @@ pub enum WebSocketError {
 #[must_use = "WebSocket is closed on drop"]
 pub struct WebSocket {
     ws: web_sys::WebSocket,
+    callbacks: Callbacks,
 }
 
 impl WebSocket {
@@ -251,7 +252,7 @@ impl WebSocket {
             ws.set_onmessage(Some(on_message.as_ref().unchecked_ref()))
         }
 
-        Ok(Self { ws })
+        Ok(Self { ws, callbacks })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,8 @@ pub mod prelude {
         },
         browser::fetch::{self, fetch, FetchError, Header, Method, Request, Response, Status},
         browser::util::{
-            request_animation_frame, RequestAnimationFrameHandle, RequestAnimationFrameTime,
+            request_animation_frame, RequestAnimationFrameHandle,
+            RequestAnimationFrameTime,
         },
         browser::web_socket::{self, CloseEvent, WebSocket, WebSocketError, WebSocketMessage},
         browser::web_storage::{self, LocalStorage, SessionStorage, WebStorage},


### PR DESCRIPTION
This reverts commit 08c4ce15255ac8d03df5315796e7b63e624e2987.

The fields are considered as unused by `rustc`, however they might be stored to be dropped in the right moment.

In the future we should analyze which field we can really delete, however I think we can do without such clean-up as Seed 0.8 is not the current version of Seed.

See: https://github.com/seed-rs/seed/issues/701